### PR TITLE
Add plain-text template & copy menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   ],
   "scripts": {
     "dev": "vite",
-    "build": "node scripts/optimize-previews.cjs --check && vite build && node scripts/generate-seo.cjs",
+    "build": "node scripts/optimize-previews.cjs --check && vite build && node scripts/copy-template-text.cjs && node scripts/generate-seo.cjs",
+    "copy:template-text": "node scripts/copy-template-text.cjs",
     "optimize:previews": "node scripts/optimize-previews.cjs",
     "preview": "vite preview",
     "deploy": "npm run build && gh-pages -d dist"

--- a/preview.css
+++ b/preview.css
@@ -185,10 +185,6 @@ body {
   background: transparent;
 }
 
-.action-button[hidden] {
-  display: none;
-}
-
 .action-button:disabled {
   cursor: default;
   opacity: 0.72;

--- a/preview.css
+++ b/preview.css
@@ -125,6 +125,75 @@ body {
   padding: 0 14px;
 }
 
+.copy-menu {
+  position: relative;
+}
+
+.chevron-icon {
+  height: 14px;
+  width: 14px;
+}
+
+.copy-menu-list {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 12px 30px rgba(23, 32, 51, 0.14);
+  min-width: 190px;
+  padding: 6px;
+  position: absolute;
+  right: 0;
+  top: calc(100% + 8px);
+  z-index: 20;
+}
+
+.copy-menu-list[hidden],
+.copy-menu-item[hidden] {
+  display: none;
+}
+
+.copy-menu-item {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  color: #344054;
+  cursor: pointer;
+  display: flex;
+  font: inherit;
+  font-size: 14px;
+  font-weight: 600;
+  gap: 10px;
+  min-height: 38px;
+  padding: 0 10px;
+  text-align: left;
+  width: 100%;
+}
+
+.copy-menu-item:hover,
+.copy-menu-item:focus-visible {
+  background: #f9fafb;
+  outline: none;
+}
+
+.copy-menu-item:disabled {
+  cursor: default;
+  opacity: 0.62;
+}
+
+.copy-menu-item:disabled:hover {
+  background: transparent;
+}
+
+.action-button[hidden] {
+  display: none;
+}
+
+.action-button:disabled {
+  cursor: default;
+  opacity: 0.72;
+}
+
 .action-button.secondary {
   background: var(--surface);
   color: #344054;

--- a/preview.css
+++ b/preview.css
@@ -147,8 +147,7 @@ body {
   z-index: 20;
 }
 
-.copy-menu-list[hidden],
-.copy-menu-item[hidden] {
+.copy-menu-list[hidden] {
   display: none;
 }
 
@@ -174,15 +173,6 @@ body {
 .copy-menu-item:focus-visible {
   background: #f9fafb;
   outline: none;
-}
-
-.copy-menu-item:disabled {
-  cursor: default;
-  opacity: 0.62;
-}
-
-.copy-menu-item:disabled:hover {
-  background: transparent;
 }
 
 .action-button:disabled {

--- a/preview.html
+++ b/preview.html
@@ -107,7 +107,6 @@
               type="button"
               id="copy-text-menu-item"
               role="menuitem"
-              hidden
             >
               <svg
                 class="icon"

--- a/preview.html
+++ b/preview.html
@@ -41,18 +41,92 @@
       </div>
 
       <div class="toolbar-right">
-        <button class="action-button secondary" type="button" id="copy-button">
-          <svg class="icon" viewBox="0 0 20 20" fill="none" aria-hidden="true">
-            <path
-              d="M7 7V5.5C7 4.67 7.67 4 8.5 4H14.5C15.33 4 16 4.67 16 5.5V11.5C16 12.33 15.33 13 14.5 13H13M5.5 7H11.5C12.33 7 13 7.67 13 8.5V14.5C13 15.33 12.33 16 11.5 16H5.5C4.67 16 4 15.33 4 14.5V8.5C4 7.67 4.67 7 5.5 7Z"
-              stroke="currentColor"
-              stroke-width="1.7"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            />
-          </svg>
-          <span>Copy HTML</span>
-        </button>
+        <div class="copy-menu" id="copy-menu">
+          <button
+            class="action-button secondary"
+            type="button"
+            id="copy-menu-button"
+            aria-haspopup="menu"
+            aria-expanded="false"
+          >
+            <svg
+              class="icon"
+              viewBox="0 0 20 20"
+              fill="none"
+              aria-hidden="true"
+            >
+              <path
+                d="M7 7V5.5C7 4.67 7.67 4 8.5 4H14.5C15.33 4 16 4.67 16 5.5V11.5C16 12.33 15.33 13 14.5 13H13M5.5 7H11.5C12.33 7 13 7.67 13 8.5V14.5C13 15.33 12.33 16 11.5 16H5.5C4.67 16 4 15.33 4 14.5V8.5C4 7.67 4.67 7 5.5 7Z"
+                stroke="currentColor"
+                stroke-width="1.7"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            <span>Copy</span>
+            <svg
+              class="icon chevron-icon"
+              viewBox="0 0 20 20"
+              fill="none"
+              aria-hidden="true"
+            >
+              <path
+                d="M6 8L10 12L14 8"
+                stroke="currentColor"
+                stroke-width="1.8"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </button>
+          <div class="copy-menu-list" id="copy-menu-list" role="menu" hidden>
+            <button
+              class="copy-menu-item"
+              type="button"
+              id="copy-html-menu-item"
+              role="menuitem"
+            >
+              <svg
+                class="icon"
+                viewBox="0 0 20 20"
+                fill="none"
+                aria-hidden="true"
+              >
+                <path
+                  d="M7 7V5.5C7 4.67 7.67 4 8.5 4H14.5C15.33 4 16 4.67 16 5.5V11.5C16 12.33 15.33 13 14.5 13H13M5.5 7H11.5C12.33 7 13 7.67 13 8.5V14.5C13 15.33 12.33 16 11.5 16H5.5C4.67 16 4 15.33 4 14.5V8.5C4 7.67 4.67 7 5.5 7Z"
+                  stroke="currentColor"
+                  stroke-width="1.7"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <span>Copy HTML</span>
+            </button>
+            <button
+              class="copy-menu-item"
+              type="button"
+              id="copy-text-menu-item"
+              role="menuitem"
+              hidden
+            >
+              <svg
+                class="icon"
+                viewBox="0 0 20 20"
+                fill="none"
+                aria-hidden="true"
+              >
+                <path
+                  d="M6 5.5H14M6 9H14M6 12.5H11.5M4.5 3.5H15.5V16.5H4.5V3.5Z"
+                  stroke="currentColor"
+                  stroke-width="1.7"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <span>Copy plain text</span>
+            </button>
+          </div>
+        </div>
         <a class="action-button primary" id="download-link" href="#" download>
           <svg class="icon" viewBox="0 0 20 20" fill="none" aria-hidden="true">
             <path

--- a/preview.js
+++ b/preview.js
@@ -2,86 +2,103 @@ const templates = {
   "purchase-confirmation": {
     title: "Purchase Confirmation Emailer",
     file: "./templates/purchase-confirmation.html",
+    plainTextFile: "./templates/purchase-confirmation.txt",
     background: "#f4f4f4",
   },
   "product-confirmation": {
     title: "Product Confirmation Emailer",
     file: "./templates/product-confirmation.html",
+    plainTextFile: "./templates/product-confirmation.txt",
     background: "#f4f4f4",
   },
   "ecommerce-order": {
     title: "Ecommerce Order Emailer",
     file: "./templates/ecommerce-order.html",
+    plainTextFile: "./templates/ecommerce-order.txt",
     background: "#fff5f0",
   },
   "promotional-offer": {
     title: "Promotional Offer Emailer",
     file: "./templates/promotional-offer.html",
+    plainTextFile: "./templates/promotional-offer.txt",
     background: "#ff9b12",
   },
   "shopping-deals": {
     title: "Shopping Deals Emailer",
     file: "./templates/shopping-deals.html",
+    plainTextFile: "./templates/shopping-deals.txt",
     background: "#f4f4f4",
   },
   "gift-decor": {
     title: "Gift Decor Emailer",
     file: "./templates/gift-decor.html",
+    plainTextFile: "./templates/gift-decor.txt",
     background: "rgb(36, 3, 54)",
   },
   "product-announcements": {
     title: "Product Announcements Emailer",
     file: "./templates/product-announcements.html",
+    plainTextFile: "./templates/product-announcements.txt",
     background: "#ffffff",
   },
   "ai-newsletter": {
     title: "AI Newsletter Emailer",
     file: "./templates/ai-newsletter.html",
+    plainTextFile: "./templates/ai-newsletter.txt",
     background: "#06120d",
   },
   "music-event-promotion": {
     title: "Music Event Promotion Emailer",
     file: "./templates/music-event-promotion.html",
+    plainTextFile: "./templates/music-event-promotion.txt",
     background: "#f4f4f4",
   },
   "abandoned-cart": {
     title: "Abandoned Cart Emailer",
     file: "./templates/abandoned-cart.html",
+    plainTextFile: "./templates/abandoned-cart.txt",
     background: "#ffffff",
   },
   "password-reset": {
     title: "Password Reset Emailer",
     file: "./templates/password-reset.html",
+    plainTextFile: "./templates/password-reset.txt",
     background: "#f4f4f4",
   },
   "account-verification": {
     title: "Account Verification Emailer",
     file: "./templates/account-verification.html",
+    plainTextFile: "./templates/account-verification.txt",
     background: "#fafaf9",
   },
   "welcome-onboarding": {
     title: "Welcome Onboarding Emailer",
     file: "./templates/welcome-onboarding.html",
+    plainTextFile: "./templates/welcome-onboarding.txt",
     background: "#f4f4f4",
   },
   "product-review": {
     title: "Product Review HTML Template",
     file: "./templates/product-review.html",
+    plainTextFile: "./templates/product-review.txt",
     background: "#f4f4f4",
   },
   reengagement: {
     title: "Re-engagement HTML Email",
     file: "./templates/reengagement.html",
+    plainTextFile: "./templates/reengagement.txt",
     background: "#f8fafc",
   },
   "account-billing-update": {
     title: "Account & Billing Update Emailer",
     file: "./templates/account-billing-update.html",
+    plainTextFile: "./templates/account-billing-update.txt",
     background: "#eef2f7",
   },
   "product-promotion": {
     title: "Product Promotion HTML Email Template",
     file: "./templates/product-promotion.html",
+    plainTextFile: "./templates/product-promotion.txt",
     background: "#141a08",
   },
 };
@@ -96,9 +113,14 @@ const frameShell = document.getElementById("frame-shell");
 const frameScaler = document.getElementById("frame-scaler");
 const stage = document.getElementById("preview-stage");
 const downloadLink = document.getElementById("download-link");
-const copyButton = document.getElementById("copy-button");
+const copyMenu = document.getElementById("copy-menu");
+const copyMenuButton = document.getElementById("copy-menu-button");
+const copyMenuList = document.getElementById("copy-menu-list");
+const copyHtmlMenuItem = document.getElementById("copy-html-menu-item");
+const copyTextMenuItem = document.getElementById("copy-text-menu-item");
 const FRAME_MIN_WIDTH = 600;
 let frameResizeObservers = [];
+const fileContentCache = new Map();
 
 const getFallbackFrameHeight = () =>
   window.innerHeight - document.querySelector(".preview-toolbar").offsetHeight;
@@ -109,6 +131,13 @@ frame.src = template.file;
 stage.style.setProperty("--template-bg", template.background);
 downloadLink.href = template.file;
 downloadLink.download = template.file.split("/").pop();
+
+if (template.plainTextFile) {
+  copyTextMenuItem.hidden = false;
+}
+
+copyHtmlMenuItem.disabled = true;
+copyTextMenuItem.disabled = true;
 
 const getFrameContentHeight = () => {
   try {
@@ -205,21 +234,98 @@ new ResizeObserver(syncToolbarHeight).observe(
   document.querySelector(".preview-toolbar"),
 );
 
-copyButton.addEventListener("click", async () => {
-  const original = copyButton.innerHTML;
+const setCopyMenuOpen = (isOpen) => {
+  copyMenuList.hidden = !isOpen;
+  copyMenuButton.setAttribute("aria-expanded", String(isOpen));
+};
+
+const getFileContent = async (file) => {
+  if (fileContentCache.has(file)) return fileContentCache.get(file);
+
+  const response = await fetch(file);
+  if (!response.ok) throw new Error("Unable to load template");
+  const content = await response.text();
+  fileContentCache.set(file, content);
+
+  return content;
+};
+
+getFileContent(template.file).finally(() => {
+  copyHtmlMenuItem.disabled = false;
+});
+if (template.plainTextFile) {
+  getFileContent(template.plainTextFile).finally(() => {
+    copyTextMenuItem.disabled = false;
+  });
+}
+
+const copyFileToClipboard = async (button, file, successText) => {
+  const original = button.innerHTML;
+  button.disabled = true;
   try {
-    const response = await fetch(template.file);
-    if (!response.ok) throw new Error("Unable to load template");
-    const html = await response.text();
-    await navigator.clipboard.writeText(html);
-    copyButton.textContent = "Copied";
+    const content = await getFileContent(file);
+    await writeToClipboard(content);
+    button.textContent = successText;
     setTimeout(() => {
-      copyButton.innerHTML = original;
+      button.innerHTML = original;
+      button.disabled = false;
     }, 1400);
   } catch (error) {
-    copyButton.textContent = "Copy failed";
+    button.textContent = "Copy failed";
     setTimeout(() => {
-      copyButton.innerHTML = original;
+      button.innerHTML = original;
+      button.disabled = false;
     }, 1600);
   }
+};
+
+const writeToClipboard = async (content) => {
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(content);
+      return;
+    } catch (error) {
+      // Fall back for browsers or contexts that block the async Clipboard API.
+    }
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = content;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.left = "-9999px";
+  textarea.style.top = "0";
+  document.body.append(textarea);
+  textarea.select();
+
+  const copied = document.execCommand("copy");
+  textarea.remove();
+
+  if (!copied) throw new Error("Unable to copy to clipboard");
+};
+
+copyMenuButton.addEventListener("click", (event) => {
+  event.stopPropagation();
+  if (copyMenuButton.disabled) return;
+  setCopyMenuOpen(copyMenuList.hidden);
+});
+
+copyHtmlMenuItem.addEventListener("click", () => {
+  if (copyHtmlMenuItem.disabled) return;
+  setCopyMenuOpen(false);
+  copyFileToClipboard(copyMenuButton, template.file, "HTML copied");
+});
+
+copyTextMenuItem.addEventListener("click", () => {
+  if (!template.plainTextFile || copyTextMenuItem.disabled) return;
+  setCopyMenuOpen(false);
+  copyFileToClipboard(copyMenuButton, template.plainTextFile, "Text copied");
+});
+
+document.addEventListener("click", (event) => {
+  if (!copyMenu.contains(event.target)) setCopyMenuOpen(false);
+});
+
+document.addEventListener("keydown", (event) => {
+  if (event.key === "Escape") setCopyMenuOpen(false);
 });

--- a/preview.js
+++ b/preview.js
@@ -2,103 +2,86 @@ const templates = {
   "purchase-confirmation": {
     title: "Purchase Confirmation Emailer",
     file: "./templates/purchase-confirmation.html",
-    plainTextFile: "./templates/purchase-confirmation.txt",
     background: "#f4f4f4",
   },
   "product-confirmation": {
     title: "Product Confirmation Emailer",
     file: "./templates/product-confirmation.html",
-    plainTextFile: "./templates/product-confirmation.txt",
     background: "#f4f4f4",
   },
   "ecommerce-order": {
     title: "Ecommerce Order Emailer",
     file: "./templates/ecommerce-order.html",
-    plainTextFile: "./templates/ecommerce-order.txt",
     background: "#fff5f0",
   },
   "promotional-offer": {
     title: "Promotional Offer Emailer",
     file: "./templates/promotional-offer.html",
-    plainTextFile: "./templates/promotional-offer.txt",
     background: "#ff9b12",
   },
   "shopping-deals": {
     title: "Shopping Deals Emailer",
     file: "./templates/shopping-deals.html",
-    plainTextFile: "./templates/shopping-deals.txt",
     background: "#f4f4f4",
   },
   "gift-decor": {
     title: "Gift Decor Emailer",
     file: "./templates/gift-decor.html",
-    plainTextFile: "./templates/gift-decor.txt",
     background: "rgb(36, 3, 54)",
   },
   "product-announcements": {
     title: "Product Announcements Emailer",
     file: "./templates/product-announcements.html",
-    plainTextFile: "./templates/product-announcements.txt",
     background: "#ffffff",
   },
   "ai-newsletter": {
     title: "AI Newsletter Emailer",
     file: "./templates/ai-newsletter.html",
-    plainTextFile: "./templates/ai-newsletter.txt",
     background: "#06120d",
   },
   "music-event-promotion": {
     title: "Music Event Promotion Emailer",
     file: "./templates/music-event-promotion.html",
-    plainTextFile: "./templates/music-event-promotion.txt",
     background: "#f4f4f4",
   },
   "abandoned-cart": {
     title: "Abandoned Cart Emailer",
     file: "./templates/abandoned-cart.html",
-    plainTextFile: "./templates/abandoned-cart.txt",
     background: "#ffffff",
   },
   "password-reset": {
     title: "Password Reset Emailer",
     file: "./templates/password-reset.html",
-    plainTextFile: "./templates/password-reset.txt",
     background: "#f4f4f4",
   },
   "account-verification": {
     title: "Account Verification Emailer",
     file: "./templates/account-verification.html",
-    plainTextFile: "./templates/account-verification.txt",
     background: "#fafaf9",
   },
   "welcome-onboarding": {
     title: "Welcome Onboarding Emailer",
     file: "./templates/welcome-onboarding.html",
-    plainTextFile: "./templates/welcome-onboarding.txt",
     background: "#f4f4f4",
   },
   "product-review": {
     title: "Product Review HTML Template",
     file: "./templates/product-review.html",
-    plainTextFile: "./templates/product-review.txt",
     background: "#f4f4f4",
   },
   reengagement: {
     title: "Re-engagement HTML Email",
     file: "./templates/reengagement.html",
-    plainTextFile: "./templates/reengagement.txt",
     background: "#f8fafc",
   },
   "account-billing-update": {
     title: "Account & Billing Update Emailer",
     file: "./templates/account-billing-update.html",
-    plainTextFile: "./templates/account-billing-update.txt",
     background: "#eef2f7",
   },
   "product-promotion": {
     title: "Product Promotion HTML Email Template",
     file: "./templates/product-promotion.html",
-    plainTextFile: "./templates/product-promotion.txt",
     background: "#141a08",
   },
 };
@@ -106,6 +89,7 @@ const templates = {
 const params = new URLSearchParams(window.location.search);
 const id = params.get("template") || "purchase-confirmation";
 const template = templates[id] || templates["purchase-confirmation"];
+const plainTextFile = template.file.replace(/\.html$/, ".txt");
 const title = `${template.title} | Email Template Preview`;
 const titleNode = document.getElementById("template-title");
 const frame = document.getElementById("template-frame");
@@ -120,7 +104,6 @@ const copyHtmlMenuItem = document.getElementById("copy-html-menu-item");
 const copyTextMenuItem = document.getElementById("copy-text-menu-item");
 const FRAME_MIN_WIDTH = 600;
 let frameResizeObservers = [];
-const fileContentCache = new Map();
 
 const getFallbackFrameHeight = () =>
   window.innerHeight - document.querySelector(".preview-toolbar").offsetHeight;
@@ -131,13 +114,6 @@ frame.src = template.file;
 stage.style.setProperty("--template-bg", template.background);
 downloadLink.href = template.file;
 downloadLink.download = template.file.split("/").pop();
-
-if (template.plainTextFile) {
-  copyTextMenuItem.hidden = false;
-}
-
-copyHtmlMenuItem.disabled = true;
-copyTextMenuItem.disabled = true;
 
 const getFrameContentHeight = () => {
   try {
@@ -240,24 +216,10 @@ const setCopyMenuOpen = (isOpen) => {
 };
 
 const getFileContent = async (file) => {
-  if (fileContentCache.has(file)) return fileContentCache.get(file);
-
   const response = await fetch(file);
   if (!response.ok) throw new Error("Unable to load template");
-  const content = await response.text();
-  fileContentCache.set(file, content);
-
-  return content;
+  return response.text();
 };
-
-getFileContent(template.file).finally(() => {
-  copyHtmlMenuItem.disabled = false;
-});
-if (template.plainTextFile) {
-  getFileContent(template.plainTextFile).finally(() => {
-    copyTextMenuItem.disabled = false;
-  });
-}
 
 const copyFileToClipboard = async (button, file, successText) => {
   const original = button.innerHTML;
@@ -317,9 +279,9 @@ copyHtmlMenuItem.addEventListener("click", () => {
 });
 
 copyTextMenuItem.addEventListener("click", () => {
-  if (!template.plainTextFile || copyTextMenuItem.disabled) return;
+  if (copyTextMenuItem.disabled) return;
   setCopyMenuOpen(false);
-  copyFileToClipboard(copyMenuButton, template.plainTextFile, "Text copied");
+  copyFileToClipboard(copyMenuButton, plainTextFile, "Text copied");
 });
 
 document.addEventListener("click", (event) => {

--- a/preview.js
+++ b/preview.js
@@ -226,7 +226,7 @@ const copyFileToClipboard = async (button, file, successText) => {
   button.disabled = true;
   try {
     const content = await getFileContent(file);
-    await writeToClipboard(content);
+    await navigator.clipboard.writeText(content);
     button.textContent = successText;
     setTimeout(() => {
       button.innerHTML = original;
@@ -241,31 +241,6 @@ const copyFileToClipboard = async (button, file, successText) => {
   }
 };
 
-const writeToClipboard = async (content) => {
-  if (navigator.clipboard?.writeText) {
-    try {
-      await navigator.clipboard.writeText(content);
-      return;
-    } catch (error) {
-      // Fall back for browsers or contexts that block the async Clipboard API.
-    }
-  }
-
-  const textarea = document.createElement("textarea");
-  textarea.value = content;
-  textarea.setAttribute("readonly", "");
-  textarea.style.position = "fixed";
-  textarea.style.left = "-9999px";
-  textarea.style.top = "0";
-  document.body.append(textarea);
-  textarea.select();
-
-  const copied = document.execCommand("copy");
-  textarea.remove();
-
-  if (!copied) throw new Error("Unable to copy to clipboard");
-};
-
 copyMenuButton.addEventListener("click", (event) => {
   event.stopPropagation();
   if (copyMenuButton.disabled) return;
@@ -273,13 +248,11 @@ copyMenuButton.addEventListener("click", (event) => {
 });
 
 copyHtmlMenuItem.addEventListener("click", () => {
-  if (copyHtmlMenuItem.disabled) return;
   setCopyMenuOpen(false);
   copyFileToClipboard(copyMenuButton, template.file, "HTML copied");
 });
 
 copyTextMenuItem.addEventListener("click", () => {
-  if (copyTextMenuItem.disabled) return;
   setCopyMenuOpen(false);
   copyFileToClipboard(copyMenuButton, plainTextFile, "Text copied");
 });

--- a/scripts/copy-template-text.cjs
+++ b/scripts/copy-template-text.cjs
@@ -1,0 +1,30 @@
+const fs = require("fs");
+const path = require("path");
+const glob = require("glob");
+
+const ROOT = path.resolve(__dirname, "..");
+const DIST_DIR = path.join(ROOT, "dist");
+
+if (!fs.existsSync(DIST_DIR)) {
+  console.error("Dist directory does not exist. Run vite build first.");
+  process.exit(1);
+}
+
+const textFiles = glob.sync("templates/**/*.txt", {
+  cwd: ROOT,
+  nodir: true,
+});
+
+textFiles.forEach((file) => {
+  const source = path.join(ROOT, file);
+  const destination = path.join(DIST_DIR, file);
+
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  fs.copyFileSync(source, destination);
+});
+
+console.log(
+  `Copied ${textFiles.length} plain-text template${
+    textFiles.length === 1 ? "" : "s"
+  }.`,
+);

--- a/templates/abandoned-cart.txt
+++ b/templates/abandoned-cart.txt
@@ -1,0 +1,52 @@
+You left something behind
+Finish your checkout in just a few clicks
+
+Hi [First name],
+
+Looks like you didn't get a chance to complete your order. We've saved
+your cart with the items below.
+
+Cart items
+
+- AeroRun Mesh Sneakers
+  Color: Graphite
+  Size: 9
+  Qty: 1
+  Price: $96.00
+
+- AirFlow Performance Cap
+  Color: Navy
+  Size: One size
+  Qty: 1
+  Price: $24.00
+
+Order summary
+
+Subtotal: $120.00
+Shipping: Free
+Tax: $0.00
+Total: $120.00
+
+Limited-time treat
+
+Use code SAVE10 at checkout for 10% off.
+
+Return to your cart:
+https://example.com/cart/restore?token=abc123
+
+We'll reserve your items for the next 24 hours.
+
+Trouble with the button? Paste this link into your browser:
+https://example.com/cart/restore?token=abc123
+
+Need help?
+
+Our team is here for you at support@example.com.
+
+You are receiving this because you visited our store but did not complete
+a purchase.
+
+Unsubscribe:
+[add URL]
+
+123 Market St, San Francisco, CA

--- a/templates/abandoned-cart.txt
+++ b/templates/abandoned-cart.txt
@@ -1,3 +1,5 @@
+Still thinking it over? Your items are waiting. Complete your order while they're in stock.
+
 You left something behind
 Finish your checkout in just a few clicks
 
@@ -32,12 +34,12 @@ Limited-time treat
 Use code SAVE10 at checkout for 10% off.
 
 Return to your cart:
-https://example.com/cart/restore?token=abc123
+[add cart restore URL]
 
 We'll reserve your items for the next 24 hours.
 
 Trouble with the button? Paste this link into your browser:
-https://example.com/cart/restore?token=abc123
+[add cart restore URL]
 
 Need help?
 
@@ -47,6 +49,6 @@ You are receiving this because you visited our store but did not complete
 a purchase.
 
 Unsubscribe:
-[add URL]
+[add unsubscribe URL]
 
 123 Market St, San Francisco, CA

--- a/templates/account-billing-update.txt
+++ b/templates/account-billing-update.txt
@@ -1,3 +1,5 @@
+Your Acme subscription has been updated. Next charge on Mar 1, 2026.
+
 Your subscription has been updated
 
 Hello John Doe, here's what's changed on your account:
@@ -34,21 +36,21 @@ What you can do next
 - Manage seats and add-ons for your team.
 
 Review billing details:
-https://acme.com/billing
+[add billing URL]
 
 Or view your latest invoice:
-INV-2048: [add URL]
+INV-2048: [add invoice URL]
 
 If the button doesn't work, copy and paste this link:
-https://acme.com/billing
+[add billing URL]
 
 Questions?
-Contact support: [add URL]
+Contact support: [add support URL]
 
 Acme, Inc.
 123 Market Street
 San Francisco, CA 94103
 
-Terms: [add URL]
-Privacy: [add URL]
-Unsubscribe: [add URL]
+Terms: [add terms URL]
+Privacy: [add privacy URL]
+Unsubscribe: [add unsubscribe URL]

--- a/templates/account-billing-update.txt
+++ b/templates/account-billing-update.txt
@@ -1,0 +1,54 @@
+Your subscription has been updated
+
+Hello John Doe, here's what's changed on your account:
+
+- Plan updated to Growth Annual.
+- New billing cycle starts on Feb 15, 2026.
+- Next charge of $588.00 on Mar 1, 2026.
+
+Account summary
+
+Plan: Growth Annual
+Next charge: Mar 1, 2026
+Status: Active
+
+Details
+
+Plan: Growth Annual
+Amount: $588.00 / year
+Billing period: Mar 1, 2026 - Feb 28, 2027
+Effective date: Feb 15, 2026
+Payment method: Visa ending in 4242
+
+Charges summary
+
+Growth Annual (1 seat): $588.00
+Proration credit: -$48.00
+Tax: $12.00
+Total due on Mar 1, 2026: $552.00
+
+What you can do next
+
+- Review billing settings and download your latest invoice.
+- Update your payment method if needed.
+- Manage seats and add-ons for your team.
+
+Review billing details:
+https://acme.com/billing
+
+Or view your latest invoice:
+INV-2048: [add URL]
+
+If the button doesn't work, copy and paste this link:
+https://acme.com/billing
+
+Questions?
+Contact support: [add URL]
+
+Acme, Inc.
+123 Market Street
+San Francisco, CA 94103
+
+Terms: [add URL]
+Privacy: [add URL]
+Unsubscribe: [add URL]

--- a/templates/account-verification.txt
+++ b/templates/account-verification.txt
@@ -1,0 +1,25 @@
+Account verification required
+Link expires in 24 hours
+
+Hello {{firstName}},
+
+Welcome to Acme. Before you begin exploring all that we have to offer, we
+need to verify your email address to ensure account security.
+
+Verify Account:
+{{verificationUrl}}
+
+If the button doesn't work, copy and paste this link into your browser:
+{{verificationUrl}}
+
+Expires in: 24 Hours
+Security: One-time link
+
+Questions? Contact our support team:
+{{contactUrl}}
+
+Sent to {{email}} on {{date}}
+
+Privacy: {{privacyUrl}}
+Terms: {{termsUrl}}
+Unsubscribe: {{unsubscribeUrl}}

--- a/templates/account-verification.txt
+++ b/templates/account-verification.txt
@@ -1,5 +1,4 @@
-Account verification required
-Link expires in 24 hours
+Account verification required • Link expires in 24 hours
 
 Hello {{firstName}},
 

--- a/templates/ai-newsletter.html
+++ b/templates/ai-newsletter.html
@@ -26,6 +26,11 @@
       background-color: #06120d;
     "
   >
+    <!-- Preheader (hidden) -->
+    <div style="display: none; font-size: 1px; color: #06120d; line-height: 1px; max-height: 0; max-width: 0; opacity: 0; overflow: hidden; mso-hide: all;">
+      Stay ahead of AI breakthroughs, healthcare use cases, and ethics updates.
+    </div>
+
     <table
       width="100%"
       bgcolor="#ffffff"

--- a/templates/ai-newsletter.txt
+++ b/templates/ai-newsletter.txt
@@ -1,3 +1,5 @@
+Stay ahead of AI breakthroughs, healthcare use cases, and ethics updates.
+
 Acme Corp
 
 Your Daily Dose of AI
@@ -13,7 +15,7 @@ breakthrough could lead to more accurate AI-powered systems in various
 industries.
 
 Read More:
-[add URL]
+[add neural network article URL]
 
 AI in Healthcare: Early Disease Detection
 
@@ -22,7 +24,7 @@ early stages. New algorithms can analyze medical images and patient data
 to identify potential health risks before symptoms even appear.
 
 Read More:
-[add URL]
+[add healthcare AI article URL]
 
 AI Ethics: Addressing Bias in Algorithms
 
@@ -31,9 +33,9 @@ Experts are working to address bias in algorithms and ensure that AI
 systems are fair and equitable for all users.
 
 Read More:
-[add URL]
+[add AI ethics article URL]
 
 (c) 2025 Daily AI News. All rights reserved.
 
 Unsubscribe:
-[add URL]
+[add unsubscribe URL]

--- a/templates/ai-newsletter.txt
+++ b/templates/ai-newsletter.txt
@@ -1,0 +1,39 @@
+Acme Corp
+
+Your Daily Dose of AI
+
+Stay ahead of the curve with the latest in Artificial Intelligence.
+Delivered to your inbox daily.
+
+AI Breakthrough: New Neural Network Architecture
+
+Researchers have developed a novel neural network architecture that
+significantly improves performance on image recognition tasks. This
+breakthrough could lead to more accurate AI-powered systems in various
+industries.
+
+Read More:
+[add URL]
+
+AI in Healthcare: Early Disease Detection
+
+AI is revolutionizing healthcare with its ability to detect diseases at
+early stages. New algorithms can analyze medical images and patient data
+to identify potential health risks before symptoms even appear.
+
+Read More:
+[add URL]
+
+AI Ethics: Addressing Bias in Algorithms
+
+The ethical implications of AI are becoming increasingly important.
+Experts are working to address bias in algorithms and ensure that AI
+systems are fair and equitable for all users.
+
+Read More:
+[add URL]
+
+(c) 2025 Daily AI News. All rights reserved.
+
+Unsubscribe:
+[add URL]

--- a/templates/ecommerce-order.html
+++ b/templates/ecommerce-order.html
@@ -50,6 +50,11 @@
     </style>
   </head>
   <body style="margin: 0; padding: 32px 16px; background-color: #fff5f0">
+    <!-- Preheader (hidden) -->
+    <div style="display: none; font-size: 1px; color: #fff5f0; line-height: 1px; max-height: 0; max-width: 0; opacity: 0; overflow: hidden; mso-hide: all;">
+      Your order is confirmed. Review delivery status, order details, and next steps.
+    </div>
+
     <!-- Main Container -->
     <table
       role="presentation"

--- a/templates/ecommerce-order.txt
+++ b/templates/ecommerce-order.txt
@@ -1,9 +1,11 @@
+Your order is confirmed. Review delivery status, order details, and next steps.
+
 acme
 
-Store: [add URL]
-Guide: [add URL]
-About: [add URL]
-Services: [add URL]
+Store: [add store URL]
+Guide: [add guide URL]
+About: [add about URL]
+Services: [add services URL]
 
 Hooray! Your order has been confirmed.
 
@@ -17,7 +19,7 @@ Status
 - Delivered
 
 View Your Order:
-[add URL]
+[add order details URL]
 
 Expected delivery timelines. Contact the seller for any order-related
 inquiries. More information is available.
@@ -50,9 +52,9 @@ Total (1 item): $26.47
 
 Contact Options
 
-Chat: acmeorder.com
+Chat: [add support chat URL]
 Call: 1 (999) 928-2938
-Email: acmeorder@gmail.com
+Email: [add support email]
 
 Have Questions About Your Watch Size?
 
@@ -61,7 +63,7 @@ offer you're receiving or how this change enhances your Trade experience,
 check out our FAQs.
 
 Read FAQs:
-[add URL]
+[add FAQ URL]
 
 Exciting news: Enjoy free shipping on next order!
 
@@ -69,12 +71,12 @@ Want to enhance your shopping experience? Enjoy complimentary shipping on
 your next order as a special treat.
 
 Shop Now:
-[add URL]
+[add shop URL]
 
-Facebook: [add URL]
-Twitter: [add URL]
-Instagram: [add URL]
-Pinterest: [add URL]
+Facebook: [add Facebook URL]
+Twitter: [add Twitter URL]
+Instagram: [add Instagram URL]
+Pinterest: [add Pinterest URL]
 
 Copyright Acme Inc. All Rights Reserved.
 123 Main St., Springfield, IL 62701
@@ -82,4 +84,4 @@ Copyright Acme Inc. All Rights Reserved.
 Prefer not to receive these emails anymore?
 
 Unsubscribe here:
-[add URL]
+[add unsubscribe URL]

--- a/templates/ecommerce-order.txt
+++ b/templates/ecommerce-order.txt
@@ -1,0 +1,85 @@
+acme
+
+Store: [add URL]
+Guide: [add URL]
+About: [add URL]
+Services: [add URL]
+
+Hooray! Your order has been confirmed.
+
+The [Company Name] will commence work on this immediately. You'll receive
+an email notification once it's shipped.
+
+Status
+
+- Confirmed
+- Shipped
+- Delivered
+
+View Your Order:
+[add URL]
+
+Expected delivery timelines. Contact the seller for any order-related
+inquiries. More information is available.
+
+Order details
+
+Confirmation number: #6200600
+
+Item
+
+- Transaction ID: 1806790905
+- QTY: SET OF 3
+- Color: Blue
+- Quantity: 1
+- Price: $16.85
+
+Shipping Address
+
+John Doe
+123 Main St.
+Springfield, IL 62701
+United States
+
+Paid with Card
+
+Subtotal: $16.85
+Sales tax: $1.50
+Shipping: $8.12
+Total (1 item): $26.47
+
+Contact Options
+
+Chat: acmeorder.com
+Call: 1 (999) 928-2938
+Email: acmeorder@gmail.com
+
+Have Questions About Your Watch Size?
+
+We've updated our watch size! If you're wondering about the amount of
+offer you're receiving or how this change enhances your Trade experience,
+check out our FAQs.
+
+Read FAQs:
+[add URL]
+
+Exciting news: Enjoy free shipping on next order!
+
+Want to enhance your shopping experience? Enjoy complimentary shipping on
+your next order as a special treat.
+
+Shop Now:
+[add URL]
+
+Facebook: [add URL]
+Twitter: [add URL]
+Instagram: [add URL]
+Pinterest: [add URL]
+
+Copyright Acme Inc. All Rights Reserved.
+123 Main St., Springfield, IL 62701
+
+Prefer not to receive these emails anymore?
+
+Unsubscribe here:
+[add URL]

--- a/templates/gift-decor.html
+++ b/templates/gift-decor.html
@@ -18,6 +18,11 @@
       font-size: 16px;
     "
   >
+    <!-- Preheader (hidden) -->
+    <div style="display: none; font-size: 1px; color: rgb(36, 3, 54); line-height: 1px; max-height: 0; max-width: 0; opacity: 0; overflow: hidden; mso-hide: all;">
+      Get 20% off gifts and decor with code MightySave20.
+    </div>
+
     <!--[if mso]>
       <style type="text/css">
         body,

--- a/templates/gift-decor.txt
+++ b/templates/gift-decor.txt
@@ -1,12 +1,12 @@
-Get 20% off now with code MightySave20!
+Get 20% off gifts and decor with code MightySave20.
 
 Home Decor
 
-Gifts: [add URL]
-Latest Arrivals: [add URL]
-Best Sellers: [add URL]
-Gift Ideas: [add URL]
-Discounts: [add URL]
+Gifts: [add gifts URL]
+Latest Arrivals: [add latest arrivals URL]
+Best Sellers: [add best sellers URL]
+Gift Ideas: [add gift ideas URL]
+Discounts: [add discounts URL]
 
 Mighty gifts for your loved one
 
@@ -23,7 +23,7 @@ No Halloween is complete without a bold black cat! It can hold a generous
 amount of hot cocoa.
 
 Explore Category:
-[add URL]
+[add category URL]
 
 Mighty Chocolate
 
@@ -31,14 +31,14 @@ Kids adore chocolates, and when it's crafted just for them, they enjoy it
 even more.
 
 Place Custom Order:
-[add URL]
+[add custom order URL]
 
 Mighty Candles
 
 Adorable candles serve as a stunning centerpiece for New Year's Eve.
 
 Explore Scents:
-[add URL]
+[add candle scents URL]
 
 Why choose us?
 
@@ -59,17 +59,17 @@ Follow us @acme_gift
 
 Followed by 99K amazing people
 
-Support: [add URL]
-Returns: [add URL]
-FAQs: [add URL]
-Privacy Policy: [add URL]
+Support: [add support URL]
+Returns: [add returns URL]
+FAQs: [add FAQ URL]
+Privacy Policy: [add privacy URL]
 
-Instagram: [add URL]
-Twitter: [add URL]
-YouTube: [add URL]
+Instagram: [add Instagram URL]
+Twitter: [add Twitter URL]
+YouTube: [add YouTube URL]
 
 4909 Xyzabc Dr.
 Mydeson, California 92938, USA
 
-Manage Preferences: [add URL]
-Unsubscribe: [add URL]
+Manage Preferences: [add preferences URL]
+Unsubscribe: [add unsubscribe URL]

--- a/templates/gift-decor.txt
+++ b/templates/gift-decor.txt
@@ -1,0 +1,75 @@
+Get 20% off now with code MightySave20!
+
+Home Decor
+
+Gifts: [add URL]
+Latest Arrivals: [add URL]
+Best Sellers: [add URL]
+Gift Ideas: [add URL]
+Discounts: [add URL]
+
+Mighty gifts for your loved one
+
+Featured: Mighty Happy Mug
+
+This is a season for enjoyment and meaningful gift.
+
+Use this code:
+MightySave2025100
+
+Mighty Ghost Mug
+
+No Halloween is complete without a bold black cat! It can hold a generous
+amount of hot cocoa.
+
+Explore Category:
+[add URL]
+
+Mighty Chocolate
+
+Kids adore chocolates, and when it's crafted just for them, they enjoy it
+even more.
+
+Place Custom Order:
+[add URL]
+
+Mighty Candles
+
+Adorable candles serve as a stunning centerpiece for New Year's Eve.
+
+Explore Scents:
+[add URL]
+
+Why choose us?
+
+5 stars
+
+The perfect gift ever!
+
+Adorable! I'm thrilled with the quality of this product. I absolutely love
+it. I wish I hadn't ordered it during the hot weather, as it did melt
+slightly, but it's hardly noticeable.
+
+John Doe, Designer
+
+Excellent - 5 stars
+420 reviews on Mypilot
+
+Follow us @acme_gift
+
+Followed by 99K amazing people
+
+Support: [add URL]
+Returns: [add URL]
+FAQs: [add URL]
+Privacy Policy: [add URL]
+
+Instagram: [add URL]
+Twitter: [add URL]
+YouTube: [add URL]
+
+4909 Xyzabc Dr.
+Mydeson, California 92938, USA
+
+Manage Preferences: [add URL]
+Unsubscribe: [add URL]

--- a/templates/music-event-promotion.html
+++ b/templates/music-event-promotion.html
@@ -27,6 +27,11 @@
       background-color: #f4f4f4;
     "
   >
+    <!-- Preheader (hidden) -->
+    <div style="display: none; font-size: 1px; color: #f4f4f4; line-height: 1px; max-height: 0; max-width: 0; opacity: 0; overflow: hidden; mso-hide: all;">
+      Coldplayyy live tickets, event details, and VIP options inside.
+    </div>
+
     <table
       role="presentation"
       align="center"

--- a/templates/music-event-promotion.txt
+++ b/templates/music-event-promotion.txt
@@ -1,3 +1,5 @@
+Coldplayyy live tickets, event details, and VIP options inside.
+
 Coldplayyy Live!
 An Unforgettable Night
 
@@ -8,7 +10,7 @@ greatest hits and new anthems. Get ready for a spectacular show filled
 with lights, music, and unforgettable moments.
 
 Get Your Tickets Now:
-https://example.com/tickets
+[add tickets URL]
 
 Event Details
 
@@ -17,7 +19,7 @@ Time: Doors Open 6:00 PM, Show Starts 7:30 PM
 Venue: Grand Arena, City Center
 
 Get Directions:
-https://www.google.com/maps/search/Grand+Arena+City+Center
+[add venue directions URL]
 
 About Coldplayyy
 
@@ -43,16 +45,16 @@ $299
 Premium seating, exclusive access
 
 Secure Your Spot:
-https://example.com/tickets
+[add tickets URL]
 
 Spread the Word
 
-Facebook: https://www.facebook.com/coldplayyy
-Twitter: https://twitter.com/coldplayyy
-Instagram: https://www.instagram.com/coldplayyy
-YouTube: https://www.youtube.com/coldplayyy
+Facebook: [add Facebook URL]
+Twitter: [add Twitter URL]
+Instagram: [add Instagram URL]
+YouTube: [add YouTube URL]
 
 (c) 2025 Coldplayyy Event Promotion. All rights reserved.
 
-Privacy Policy: https://example.com/privacy
-Unsubscribe: https://example.com/unsubscribe
+Privacy Policy: [add privacy URL]
+Unsubscribe: [add unsubscribe URL]

--- a/templates/music-event-promotion.txt
+++ b/templates/music-event-promotion.txt
@@ -1,0 +1,58 @@
+Coldplayyy Live!
+An Unforgettable Night
+
+Experience the Magic Live
+
+Join us for an electrifying night with Coldplayyy, performing their
+greatest hits and new anthems. Get ready for a spectacular show filled
+with lights, music, and unforgettable moments.
+
+Get Your Tickets Now:
+https://example.com/tickets
+
+Event Details
+
+Date: Saturday, October 26, 2025
+Time: Doors Open 6:00 PM, Show Starts 7:30 PM
+Venue: Grand Arena, City Center
+
+Get Directions:
+https://www.google.com/maps/search/Grand+Arena+City+Center
+
+About Coldplayyy
+
+Coldplayyy is a British rock band formed in London in 1997. They achieved
+worldwide fame with their hit single "Yellow" in 2000. Known for their
+anthemic sound and visually stunning live performances, Coldplayyy has
+sold over 100 million albums worldwide, making them one of the
+best-selling music artists of all time. Their music often explores themes
+of love, hope, and unity, resonating with millions across the globe.
+
+Ticket Information
+
+General Admission
+$95
+Standing access
+
+Reserved Seating
+$150
+Assigned seating
+
+VIP Experience
+$299
+Premium seating, exclusive access
+
+Secure Your Spot:
+https://example.com/tickets
+
+Spread the Word
+
+Facebook: https://www.facebook.com/coldplayyy
+Twitter: https://twitter.com/coldplayyy
+Instagram: https://www.instagram.com/coldplayyy
+YouTube: https://www.youtube.com/coldplayyy
+
+(c) 2025 Coldplayyy Event Promotion. All rights reserved.
+
+Privacy Policy: https://example.com/privacy
+Unsubscribe: https://example.com/unsubscribe

--- a/templates/password-reset.txt
+++ b/templates/password-reset.txt
@@ -1,3 +1,5 @@
+🔐 Secure password reset requested. Click to set your new password safely. Expires in 60 minutes.
+
 Secure Password Reset
 Your account security is our priority
 
@@ -9,18 +11,18 @@ create a new password.
 This link expires in 60 minutes.
 
 Reset My Password:
-[add URL]
+[add password reset URL]
 
 Button not working?
 Use this direct link:
-[add URL]
+[add password reset URL]
 
 Didn't request this? Safely ignore this email or contact support.
 
 Contact support:
-[add URL]
+[add support URL]
 
 (c) 2025 Acme Inc.
 
 Contact Support:
-[add URL]
+[add support URL]

--- a/templates/password-reset.txt
+++ b/templates/password-reset.txt
@@ -1,0 +1,26 @@
+Secure Password Reset
+Your account security is our priority
+
+Hi [Name],
+
+We received a request to reset your password. Click the button below to
+create a new password.
+
+This link expires in 60 minutes.
+
+Reset My Password:
+[add URL]
+
+Button not working?
+Use this direct link:
+[add URL]
+
+Didn't request this? Safely ignore this email or contact support.
+
+Contact support:
+[add URL]
+
+(c) 2025 Acme Inc.
+
+Contact Support:
+[add URL]

--- a/templates/product-announcements.html
+++ b/templates/product-announcements.html
@@ -27,6 +27,11 @@
       line-height: 1.5;
     "
   >
+    <!-- Preheader (hidden) -->
+    <div style="display: none; font-size: 1px; color: #ffffff; line-height: 1px; max-height: 0; max-width: 0; opacity: 0; overflow: hidden; mso-hide: all;">
+      See the latest product updates, platform improvements, and hiring news.
+    </div>
+
     <table
       width="100%"
       border="0"

--- a/templates/product-announcements.txt
+++ b/templates/product-announcements.txt
@@ -1,3 +1,5 @@
+See the latest product updates, platform improvements, and hiring news.
+
 Product Announcements
 May 2025
 
@@ -31,7 +33,7 @@ Learn more about these integration-focused features on our blog. Both
 require a Professional plan or higher.
 
 Read Blog Post:
-[add URL]
+[add blog post URL]
 
 PLATFORM
 Latest Improvements
@@ -46,7 +48,7 @@ adipiscing elit.
 
 Interested in upgrading to Enterprise?
 Reach out:
-[add URL]
+[add enterprise contact URL]
 
 Longer feature title can go here, it can be a bit longer
 
@@ -78,7 +80,7 @@ as Postgres and Key Value.
 
 We're hiring across multiple teams!
 Check out our careers page:
-[add URL]
+[add careers URL]
 
 Company Name, Inc.
 123 Main St.
@@ -86,9 +88,9 @@ San Francisco, California
 
 (c) 2025 Company Name Inc. All rights reserved.
 
-Twitter: [add URL]
-LinkedIn: [add URL]
-GitHub: [add URL]
+Twitter: [add Twitter URL]
+LinkedIn: [add LinkedIn URL]
+GitHub: [add GitHub URL]
 
-Unsubscribe: [add URL]
-Manage preferences: [add URL]
+Unsubscribe: [add unsubscribe URL]
+Manage preferences: [add preferences URL]

--- a/templates/product-announcements.txt
+++ b/templates/product-announcements.txt
@@ -1,0 +1,94 @@
+Product Announcements
+May 2025
+
+This month, we're highlighting powerful new ways to connect your product
+with your team's other tools and providers.
+
+New product features
+
+INTEGRATIONS
+Features 1
+
+New Release
+Feature title can go here
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor
+sit amet, consectetur adipiscing elit.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+
+New Release
+Feature title can go here, it can be a bit longer
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor
+sit amet, consectetur adipiscing elit:
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor
+sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet,
+consectetur adipiscing elit.
+
+Learn more about these integration-focused features on our blog. Both
+require a Professional plan or higher.
+
+Read Blog Post:
+[add URL]
+
+PLATFORM
+Latest Improvements
+
+Enterprise
+Feature title can go here
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor
+sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet,
+consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur
+adipiscing elit.
+
+Interested in upgrading to Enterprise?
+Reach out:
+[add URL]
+
+Longer feature title can go here, it can be a bit longer
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor
+sit amet, consectetur adipiscing elit.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor
+sit amet elit.
+
+UPDATES
+More From Your Product
+
+How-To
+Feature title can go here
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor
+sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet,
+consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur
+adipiscing elit.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor
+sit amet, consectetur adipiscing elit.
+
+Engineering Manager, company name
+
+Inspire, coach, and grow the team responsible for critical infrastructure
+products that serve as "keystones" for our customers as they scale, such
+as Postgres and Key Value.
+
+We're hiring across multiple teams!
+Check out our careers page:
+[add URL]
+
+Company Name, Inc.
+123 Main St.
+San Francisco, California
+
+(c) 2025 Company Name Inc. All rights reserved.
+
+Twitter: [add URL]
+LinkedIn: [add URL]
+GitHub: [add URL]
+
+Unsubscribe: [add URL]
+Manage preferences: [add URL]

--- a/templates/product-confirmation.html
+++ b/templates/product-confirmation.html
@@ -33,6 +33,11 @@
     </style>
   </head>
   <body style="margin: 0; padding: 0; background-color: #f4f4f4">
+    <!-- Preheader (hidden) -->
+    <div style="display: none; font-size: 1px; color: #f4f4f4; line-height: 1px; max-height: 0; max-width: 0; opacity: 0; overflow: hidden; mso-hide: all;">
+      Your order is confirmed. Review your order details inside.
+    </div>
+
     <table
       role="presentation"
       cellspacing="0"

--- a/templates/product-confirmation.txt
+++ b/templates/product-confirmation.txt
@@ -1,0 +1,17 @@
+Company Logo
+
+Order confirmation
+
+Hi [Customer],
+
+Thank you for shopping with us! We've received your order No: 52777. We
+will notify you when we send it.
+
+Order summary
+
+Apple Watch Ultra 2
+From $450
+
+Subtotal: $400.00
+VAT (20.0%): $80.00
+Total: $480.00

--- a/templates/product-confirmation.txt
+++ b/templates/product-confirmation.txt
@@ -1,3 +1,5 @@
+Your order is confirmed. Review your order details inside.
+
 Company Logo
 
 Order confirmation

--- a/templates/product-promotion.txt
+++ b/templates/product-promotion.txt
@@ -1,0 +1,72 @@
+TRAILFORGE
+
+New season, new terrain. Meet the boots built to outlast the trail.
+
+AUTUMN COLLECTION 2026
+
+Built for the Climb.
+
+Engineered grip. Featherweight frames. Boots that go where the map ends.
+
+Shop the Collection:
+[add collection URL]
+
+Why TrailForge
+
+- Lifetime resole
+- Free shipping in 48 hours
+- 100% waterproof
+
+THIS WEEK'S TRAIL-TESTED
+
+Three Built Different
+
+Ridgeline GTX
+Alpine Series
+Vibram megagrip sole and a seam-sealed Gore-Tex shell. Your all-day
+mountain workhorse.
+Price: $189
+Original price: $240
+View Boot:
+[add Ridgeline GTX URL]
+
+Switchback Lite
+Speed Series
+Just 290g. A trail runner that thinks it's a sneaker, with a rock plate
+that says otherwise.
+Price: $145
+View Shoe:
+[add Switchback Lite URL]
+
+Basecamp Mid
+Backpacking Series
+Load-bearing ankle support for the heavy-pack hauls. Broken in before it
+leaves the box.
+Price: $215
+View Boot:
+[add Basecamp Mid URL]
+
+"The mountain doesn't care what you wore last season."
+- TrailForge Field Notes
+
+Not sure where you fit?
+
+Take our 60-second fit quiz and we'll match you to the boot built for
+your terrain.
+
+Find My Fit:
+[add fit quiz URL]
+
+Follow TrailForge:
+Instagram: [add Instagram URL]
+YouTube: [add YouTube URL]
+Strava: [add Strava URL]
+
+123 Summit Road
+Boulder, CO 80302
+
+Unsubscribe: [add unsubscribe URL]
+Preferences: [add preferences URL]
+View Online: [add web version URL]
+
+Copyright 2026 TrailForge Outfitters. All rights reserved.

--- a/templates/product-promotion.txt
+++ b/templates/product-promotion.txt
@@ -1,6 +1,10 @@
+New season, new terrain. Meet the boots built to outlast the trail.
+
 TRAILFORGE
 
-New season, new terrain. Meet the boots built to outlast the trail.
+Shop: [add shop URL]
+Trails: [add trails URL]
+Journal: [add journal URL]
 
 AUTUMN COLLECTION 2026
 

--- a/templates/product-review.html
+++ b/templates/product-review.html
@@ -40,6 +40,11 @@
     "
     bgcolor="#f3f4f6"
   >
+    <!-- Preheader (hidden) -->
+    <div style="display: none; font-size: 1px; color: #f3f4f6; line-height: 1px; max-height: 0; max-width: 0; opacity: 0; overflow: hidden; mso-hide: all;">
+      Tell us how your purchase went and get 10% off your next purchase.
+    </div>
+
     <!-- Outer wrapper -->
     <table
       role="presentation"

--- a/templates/product-review.txt
+++ b/templates/product-review.txt
@@ -1,3 +1,5 @@
+Tell us how your purchase went and get 10% off your next purchase.
+
 10% OFF on review - Valid 30 days
 
 Acme
@@ -20,9 +22,9 @@ Your purchase
 +2 more items
 
 Write a review:
-https://example.com/review
+[add review URL]
 
 (c) 2025 Acme Inc. - support@acme.com
 
 Unsubscribe:
-[add URL]
+[add unsubscribe URL]

--- a/templates/product-review.txt
+++ b/templates/product-review.txt
@@ -1,0 +1,28 @@
+10% OFF on review - Valid 30 days
+
+Acme
+
+Hi John, how was your purchase?
+
+A quick rating helps us improve.
+
+Your purchase
+
+- Apple Watch Ultra 2
+  Order #123456 - Delivered Sep 08, 2025
+
+- Running Shoes
+  Order #123456 - Delivered Sep 08, 2025
+
+- Cupcake Gift Box
+  Order #123456 - Delivered Sep 08, 2025
+
++2 more items
+
+Write a review:
+https://example.com/review
+
+(c) 2025 Acme Inc. - support@acme.com
+
+Unsubscribe:
+[add URL]

--- a/templates/promotional-offer.html
+++ b/templates/promotional-offer.html
@@ -10,6 +10,11 @@
     />
   </head>
   <body style="margin: 0; padding: 0; background-color: #ff9b12">
+    <!-- Preheader (hidden) -->
+    <div style="display: none; font-size: 1px; color: #ff9b12; line-height: 1px; max-height: 0; max-width: 0; opacity: 0; overflow: hidden; mso-hide: all;">
+      Black Friday deals are live. Use APPLEE40 for 40% off.
+    </div>
+
     <table
       cellpadding="0"
       cellspacing="0"

--- a/templates/promotional-offer.txt
+++ b/templates/promotional-offer.txt
@@ -1,3 +1,5 @@
+Black Friday deals are live. Use APPLEE40 for 40% off.
+
 APPLEE
 
 We are celebrating Black Friday with a 40% discount on our site. Use promo
@@ -10,28 +12,28 @@ $120
 Super comfortable lightweight design, with up to 25 hours of battery life.
 
 Buy Now:
-[add URL]
+[add Jabra Elite 75t URL]
 
 Apple AirPods
 $150
 Experience advanced noise cancellation, up to 25 hours of battery life.
 
 Buy Now:
-[add URL]
+[add Apple AirPods URL]
 
 Sony WH-100
 $199
 Premium noise cancellation, up to 30 hours of battery life.
 
 Buy Now:
-[add URL]
+[add Sony WH-100 URL]
 
 Bose QC45
 $279
 World-class noise cancellation, with exceptional comfort.
 
 Buy Now:
-[add URL]
+[add Bose QC45 URL]
 
 Our Features
 
@@ -47,20 +49,20 @@ Use app for extra discount
 25% OFF
 
 Download now:
-[add URL]
+[add app download URL]
 
 APPLEE
 
-Google Play: [add URL]
-App Store: [add URL]
+Google Play: [add Google Play URL]
+App Store: [add App Store URL]
 
 Download APPLEE app on playstore and appstore to receive monthly promos
 and updates.
 
-Instagram: [add URL]
-Twitter: [add URL]
-YouTube: [add URL]
+Instagram: [add Instagram URL]
+Twitter: [add Twitter URL]
+YouTube: [add YouTube URL]
 
 Don't want to receive this email?
 Unsubscribe:
-[add URL]
+[add unsubscribe URL]

--- a/templates/promotional-offer.txt
+++ b/templates/promotional-offer.txt
@@ -1,0 +1,66 @@
+APPLEE
+
+We are celebrating Black Friday with a 40% discount on our site. Use promo
+code APPLEE40 on your checkout. Have a great weekend!
+
+Latest Deals
+
+Jabra Elite 75t
+$120
+Super comfortable lightweight design, with up to 25 hours of battery life.
+
+Buy Now:
+[add URL]
+
+Apple AirPods
+$150
+Experience advanced noise cancellation, up to 25 hours of battery life.
+
+Buy Now:
+[add URL]
+
+Sony WH-100
+$199
+Premium noise cancellation, up to 30 hours of battery life.
+
+Buy Now:
+[add URL]
+
+Bose QC45
+$279
+World-class noise cancellation, with exceptional comfort.
+
+Buy Now:
+[add URL]
+
+Our Features
+
+- 150+ Products added
+- #1 Top appstore product
+- >1m User downloads
+- 100% Authentic products
+
+New User Deal
+
+Use app for extra discount
+
+25% OFF
+
+Download now:
+[add URL]
+
+APPLEE
+
+Google Play: [add URL]
+App Store: [add URL]
+
+Download APPLEE app on playstore and appstore to receive monthly promos
+and updates.
+
+Instagram: [add URL]
+Twitter: [add URL]
+YouTube: [add URL]
+
+Don't want to receive this email?
+Unsubscribe:
+[add URL]

--- a/templates/purchase-confirmation.html
+++ b/templates/purchase-confirmation.html
@@ -27,6 +27,11 @@
         'Helvetica Neue', Arial, sans-serif;
     "
   >
+    <!-- Preheader (hidden) -->
+    <div style="display: none; font-size: 1px; color: #f5f5f5; line-height: 1px; max-height: 0; max-width: 0; opacity: 0; overflow: hidden; mso-hide: all;">
+      Thanks for your subscription purchase. Here are your order details.
+    </div>
+
     <table
       role="presentation"
       cellspacing="0"

--- a/templates/purchase-confirmation.txt
+++ b/templates/purchase-confirmation.txt
@@ -1,3 +1,5 @@
+Thanks for your subscription purchase. Here are your order details.
+
 Logo
 
 Hi John Doe,
@@ -19,6 +21,6 @@ Co-Founder of acme.com
 
 FOLLOW US ON
 
-Facebook: [add URL]
-Instagram: [add URL]
-Twitter: [add URL]
+Facebook: [add Facebook URL]
+Instagram: [add Instagram URL]
+Twitter: [add Twitter URL]

--- a/templates/purchase-confirmation.txt
+++ b/templates/purchase-confirmation.txt
@@ -1,0 +1,24 @@
+Logo
+
+Hi John Doe,
+
+Thank you for purchasing your subscription.
+
+Order Details
+
+- Date of purchase: Sep 04, 2024
+- Amount paid: $5.99
+
+We hope you enjoy the premium experience. Thank you for supporting Acme,
+your contribution is a big deal to our tiny company.
+
+Happy coding!
+
+Jane Doe
+Co-Founder of acme.com
+
+FOLLOW US ON
+
+Facebook: [add URL]
+Instagram: [add URL]
+Twitter: [add URL]

--- a/templates/reengagement.txt
+++ b/templates/reengagement.txt
@@ -24,10 +24,10 @@ Save 20% with code WELCOME20
 Expires in 7 days - Single use
 
 Claim Your Offer:
-[add URL]
+[add offer URL]
 
-Unsubscribe: [add URL]
-View in browser: [add URL]
+Unsubscribe: [add unsubscribe URL]
+View in browser: [add web version URL]
 
 Questions? support@acme.com
 

--- a/templates/reengagement.txt
+++ b/templates/reengagement.txt
@@ -1,0 +1,35 @@
+30 days since your last visit. See what's new + get 20% off.
+
+Come back soon
+
+We miss you, John
+
+It's been 30 days since you last visited. Here's what you missed.
+
+5 New Features
+2 New Integrations
+
+What's new
+
+- Advanced Analytics: Track your progress with detailed insights.
+- Dark Mode: Easy on the eyes, day or night.
+- Faster Export: Download as PDF, Excel, or CSV.
+- 2x Faster: Improved performance across the board.
+- Team Collaboration: Invite team members and work together in real-time.
+
+Exclusive welcome-back offer
+
+Save 20% with code WELCOME20
+
+Expires in 7 days - Single use
+
+Claim Your Offer:
+[add URL]
+
+Unsubscribe: [add URL]
+View in browser: [add URL]
+
+Questions? support@acme.com
+
+(c) 2025 Acme Inc.
+123 Market Street, San Francisco, CA

--- a/templates/shopping-deals.html
+++ b/templates/shopping-deals.html
@@ -19,6 +19,11 @@
     <![endif]-->
   </head>
   <body style="margin: 0; padding: 0; background-color: #bbfea8">
+    <!-- Preheader (hidden) -->
+    <div style="display: none; font-size: 1px; color: #bbfea8; line-height: 1px; max-height: 0; max-width: 0; opacity: 0; overflow: hidden; mso-hide: all;">
+      Cyber Monday deals are here with 40% off and featured footwear offers.
+    </div>
+
     <table
       cellpadding="0"
       cellspacing="0"

--- a/templates/shopping-deals.txt
+++ b/templates/shopping-deals.txt
@@ -1,0 +1,82 @@
+Acme
+
+CYBER MONDAY
+40% OFF
+
+SHOP NOW:
+[add URL]
+
+SPECIAL OFFERS
+
+- 15% OFF - Nike K-5000 - $80
+- 25% OFF - Puma - $35
+- 20% OFF - Adidas - $70
+- 30% OFF - Nikeeee - $85
+
+VIEW MORE:
+[add URL]
+
+SHOP BY LABEL
+
+Acme
+
+View More:
+[add URL]
+
+Shop By Categories
+
+- RUNNING
+- LIFESTYLE
+- TRAINER
+
+View All:
+[add URL]
+
+Recent Posts
+
+Upcoming Release Sneak Peek
+
+Be among the first to see next year's essential sneakers. We're offering
+you an exclusive look at the new styles.
+
+Read More:
+[add URL]
+
+This Week's Most Wanted Picks
+
+Discover the styles our community loves this December. Including user
+reviews and tips.
+
+Read More:
+[add URL]
+
+Uncover The Right Footwear
+
+Numerous athletes have revealed their preferred shoes for running,
+weightlifting, or basketball.
+
+Explore their top picks & find perfect fit.
+
+View Collection:
+[add URL]
+
+Acme
+
+VIEW ALL: [add URL]
+NEW ARRIVALS: [add URL]
+OFFERS: [add URL]
+BRANDS: [add URL]
+
+Instagram: [add URL]
+YouTube: [add URL]
+
+Would you like to modify your email preferences?
+
+Update your preferences:
+[add URL]
+
+Unsubscribe:
+[add URL]
+
+Privacy Policy:
+[add URL]

--- a/templates/shopping-deals.txt
+++ b/templates/shopping-deals.txt
@@ -1,10 +1,12 @@
+Cyber Monday deals are here with 40% off and featured footwear offers.
+
 Acme
 
 CYBER MONDAY
 40% OFF
 
 SHOP NOW:
-[add URL]
+[add shop URL]
 
 SPECIAL OFFERS
 
@@ -14,14 +16,14 @@ SPECIAL OFFERS
 - 30% OFF - Nikeeee - $85
 
 VIEW MORE:
-[add URL]
+[add special offers URL]
 
 SHOP BY LABEL
 
 Acme
 
 View More:
-[add URL]
+[add label URL]
 
 Shop By Categories
 
@@ -30,7 +32,7 @@ Shop By Categories
 - TRAINER
 
 View All:
-[add URL]
+[add categories URL]
 
 Recent Posts
 
@@ -40,7 +42,7 @@ Be among the first to see next year's essential sneakers. We're offering
 you an exclusive look at the new styles.
 
 Read More:
-[add URL]
+[add upcoming release post URL]
 
 This Week's Most Wanted Picks
 
@@ -48,7 +50,7 @@ Discover the styles our community loves this December. Including user
 reviews and tips.
 
 Read More:
-[add URL]
+[add most wanted picks post URL]
 
 Uncover The Right Footwear
 
@@ -58,25 +60,25 @@ weightlifting, or basketball.
 Explore their top picks & find perfect fit.
 
 View Collection:
-[add URL]
+[add footwear collection URL]
 
 Acme
 
-VIEW ALL: [add URL]
-NEW ARRIVALS: [add URL]
-OFFERS: [add URL]
-BRANDS: [add URL]
+VIEW ALL: [add view all URL]
+NEW ARRIVALS: [add new arrivals URL]
+OFFERS: [add offers URL]
+BRANDS: [add brands URL]
 
-Instagram: [add URL]
-YouTube: [add URL]
+Instagram: [add Instagram URL]
+YouTube: [add YouTube URL]
 
 Would you like to modify your email preferences?
 
 Update your preferences:
-[add URL]
+[add preferences URL]
 
 Unsubscribe:
-[add URL]
+[add unsubscribe URL]
 
 Privacy Policy:
-[add URL]
+[add privacy URL]

--- a/templates/welcome-onboarding.txt
+++ b/templates/welcome-onboarding.txt
@@ -1,5 +1,4 @@
-Your workspace is ready. A simple 3-step checklist gets you productive
-fast.
+Your workspace is ready. A simple 3-step checklist gets you productive fast.
 
 Welcome Aboard
 Workspace
@@ -12,11 +11,11 @@ We keep onboarding intentionally simple. Start with the checklist, and
 you'll be productive in minutes.
 
 Start Onboarding:
-https://acme.app/onboarding
+[add onboarding URL]
 
 Prefer to watch first?
 See a 2-minute overview:
-[add URL]
+[add overview video URL]
 
 Checklist
 
@@ -31,7 +30,7 @@ Checklist
 
 We host office hours every Tuesday & Thursday.
 Reserve a 15-min slot:
-[add URL]
+[add office hours URL]
 
 If you didn't create this account, you can safely ignore this email.
 

--- a/templates/welcome-onboarding.txt
+++ b/templates/welcome-onboarding.txt
@@ -1,0 +1,41 @@
+Your workspace is ready. A simple 3-step checklist gets you productive
+fast.
+
+Welcome Aboard
+Workspace
+
+From Acme
+
+Hi John, your workspace is ready
+
+We keep onboarding intentionally simple. Start with the checklist, and
+you'll be productive in minutes.
+
+Start Onboarding:
+https://acme.app/onboarding
+
+Prefer to watch first?
+See a 2-minute overview:
+[add URL]
+
+Checklist
+
+1. Confirm your email
+   Secure access to your workspace and enable all features.
+
+2. Complete your profile
+   Name, photo, timezone, and a few preferences.
+
+3. Take a quick tour
+   Learn the layout and time-saving shortcuts.
+
+We host office hours every Tuesday & Thursday.
+Reserve a 15-min slot:
+[add URL]
+
+If you didn't create this account, you can safely ignore this email.
+
+Support: support@acme.com
+
+(c) 2025 Acme Inc.
+123 Market Street, San Francisco, CA


### PR DESCRIPTION
- Add plain-text (`.txt`) sidecars for all 17 email templates, copied into `dist/` during build
- Add a "Copy" menu (HTML / plain text) to the preview toolbar
- Standardize hidden preheaders across HTML templates and sync them as the first line of each `.txt`
- Standardize empty links to descriptive `[add … URL]` placeholders across all `.txt`
- Simplify the preview copy menu (use `navigator.clipboard` directly, drop dead guards/styles)