### PR TITLE
Add brand color customizer to template preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@
 ## Table of Contents
 
 1. [Live Demo](#live-demo)
-2. [Available Templates](#available-templates)
-3. [Setup](#setup-instructions)
-4. [License](#license)
+2. [Customize to Your Brand](#customize-to-your-brand)
+3. [Available Templates](#available-templates)
+4. [Setup](#setup-instructions)
+5. [License](#license)
 
 ---
 
@@ -24,6 +25,10 @@ You can access the deployed templates at [https://nirajrajgor.github.io/email-te
 ▶️ **Explore them here →** <https://nirajrajgor.github.io/email-templates/>
 
 No signup required—download with a single click!
+
+## Customize to Your Brand
+
+Template previews have a **Customize** button: pick your brand color (and on select templates, an accent color) and the whole palette re-themes live — tints, shades, and buttons stay in sync while neutral elements keep their design. Then download or copy the recolored HTML. Free, in the browser, no signup.
 
 ## Available Templates
 

--- a/customizer.js
+++ b/customizer.js
@@ -191,10 +191,9 @@ const initColorControl = (section, original, onPick) => {
     swatches.forEach((swatch) => {
       const value =
         swatch.dataset.swatch === "original" ? original : swatch.dataset.swatch;
-      swatch.classList.toggle(
-        "is-active",
-        value.toLowerCase() === hex.toLowerCase(),
-      );
+      const isActive = value.toLowerCase() === hex.toLowerCase();
+      swatch.classList.toggle("is-active", isActive);
+      swatch.setAttribute("aria-pressed", String(isActive));
     });
   };
   setValue(original);

--- a/customizer.js
+++ b/customizer.js
@@ -137,24 +137,6 @@ export const rethemeHtml = (html, fromBrand, toBrand, overrides) => {
   );
 };
 
-export const extractThemedColors = (html, overrides) => {
-  const options = buildOptions(overrides);
-  const found = new Map();
-  for (const chunk of html.match(STYLE_CONTEXT_RE) ?? []) {
-    for (const token of chunk.match(COLOR_TOKEN_RE) ?? []) {
-      const rgba = parseColorToken(token);
-      const key = rgbKey(rgba);
-      if (found.has(key) || options.pinned.has(key)) continue;
-      const hsl = rgbToHsl(rgba);
-      if (hsl.s < SATURATION_MIN && !options.themedExtra.has(key)) continue;
-      found.set(key, { hex: rgbToHex(rgba), hsl });
-    }
-  }
-  return [...found.values()]
-    .sort((a, b) => a.hsl.h - b.hsl.h || a.hsl.l - b.hsl.l)
-    .map((color) => color.hex);
-};
-
 export const rethemeCssColor = (color, fromBrand, toBrand, overrides) => {
   const match = color.match(COLOR_TOKEN_RE);
   if (!match || match[0] !== color.trim()) return color;
@@ -187,7 +169,6 @@ export const initCustomizer = ({
   const colorInput = document.getElementById("brand-color-input");
   const hexInput = document.getElementById("brand-hex-input");
   const hint = document.getElementById("contrast-hint");
-  const paletteStrip = document.getElementById("palette-strip");
   const swatches = Array.from(panel.querySelectorAll("[data-swatch]"));
   const originalSwatch = panel.querySelector('[data-swatch="original"]');
 
@@ -199,25 +180,9 @@ export const initCustomizer = ({
   let originalHtml = null;
   const ensureHtml = async () => (originalHtml ??= await loadHtml());
 
-  const renderPaletteStrip = (html) => {
-    const colors = extractThemedColors(html, { pinned, themedExtra });
-    paletteStrip.replaceChildren(
-      ...colors.map((hex) => {
-        const segment = document.createElement("span");
-        segment.className = "palette-strip-segment";
-        segment.style.setProperty("--segment", hex);
-        segment.title = hex;
-        return segment;
-      }),
-    );
-  };
-
   const setPanelOpen = (isOpen) => {
     panel.hidden = !isOpen;
     button.setAttribute("aria-expanded", String(isOpen));
-    if (isOpen && !paletteStrip.childElementCount) {
-      ensureHtml().then(renderPaletteStrip);
-    }
   };
 
   const setActiveSwatch = (hex) => {
@@ -235,14 +200,12 @@ export const initCustomizer = ({
     const html = await ensureHtml();
     const isOriginal = hex.toLowerCase() === brand.toLowerCase();
     const overrides = { pinned, themedExtra };
-    const themedHtml = isOriginal ? html : rethemeHtml(html, brand, hex, overrides);
     onApply({
-      html: themedHtml,
+      html: isOriginal ? html : rethemeHtml(html, brand, hex, overrides),
       background: isOriginal
         ? background
         : rethemeCssColor(background, brand, hex, overrides),
     });
-    renderPaletteStrip(themedHtml);
     colorInput.value = hex;
     hexInput.value = hex;
     setActiveSwatch(hex);

--- a/customizer.js
+++ b/customizer.js
@@ -178,30 +178,28 @@ const initColorControl = (section, original, onPick) => {
   const swatches = Array.from(section.querySelectorAll("[data-swatch]"));
   const colorInput = section.querySelector('input[type="color"]');
   const hexInput = section.querySelector('input[type="text"]');
-  section
-    .querySelector('[data-swatch="original"]')
-    .style.setProperty("--swatch", original);
+  const originalSwatch = section.querySelector('[data-swatch="original"]');
+  originalSwatch.style.setProperty("--swatch", original);
 
   const state = { value: original };
 
-  const setValue = (hex) => {
+  const setValue = (hex, activeSwatch = null) => {
     state.value = hex;
     colorInput.value = hex;
     hexInput.value = hex;
     swatches.forEach((swatch) => {
-      const value =
-        swatch.dataset.swatch === "original" ? original : swatch.dataset.swatch;
-      const isActive = value.toLowerCase() === hex.toLowerCase();
+      const isActive = swatch === activeSwatch;
       swatch.classList.toggle("is-active", isActive);
       swatch.setAttribute("aria-pressed", String(isActive));
     });
   };
-  setValue(original);
+  setValue(original, originalSwatch);
 
   swatches.forEach((swatch) => {
     swatch.addEventListener("click", () => {
       setValue(
         swatch.dataset.swatch === "original" ? original : swatch.dataset.swatch,
+        swatch,
       );
       onPick();
     });

--- a/customizer.js
+++ b/customizer.js
@@ -84,9 +84,10 @@ const RGB_TOKEN =
 const COLOR_TOKEN_RE = new RegExp(`${HEX_TOKEN}|${RGB_TOKEN}`, "gi");
 
 // Only rewrite colors inside style contexts so hex-like text content
-// (e.g. "Order number: #6200600") is never touched.
+// (e.g. "Order number: #6200600") is never touched. Include SVG and Outlook
+// VML color attributes, and accept either HTML attribute quote style.
 const STYLE_CONTEXT_RE =
-  /<style\b[\s\S]*?<\/style>|\b(?:style|bgcolor|color|fill|stroke)\s*=\s*"[^"]*"/gi;
+  /<style\b[\s\S]*?<\/style>|\b(?:style|bgcolor|color|fillcolor|strokecolor|fill|stroke)\s*=\s*(?:"[^"]*"|'[^']*')/gi;
 
 const parseColorToken = (token) => {
   if (token.startsWith("#")) return hexToRgba(token);

--- a/customizer.js
+++ b/customizer.js
@@ -94,10 +94,22 @@ const parseColorToken = (token) => {
   return { r: numbers[0], g: numbers[1], b: numbers[2], a: numbers[3] ?? 1 };
 };
 
-const transformToken = (token, from, to) => {
+const rgbKey = ({ r, g, b }) => `${r},${g},${b}`;
+
+// pinned: semantic colors (success badges, warnings) that must never follow
+// the brand. themedExtra: colors below the saturation threshold that still
+// belong to the brand family (e.g. muted browns in a warm monochrome theme).
+const buildOptions = ({ pinned = [], themedExtra = [] } = {}) => ({
+  pinned: new Set(pinned.map((c) => rgbKey(hexToRgba(c)))),
+  themedExtra: new Set(themedExtra.map((c) => rgbKey(hexToRgba(c)))),
+});
+
+const transformToken = (token, from, to, options) => {
   const rgba = parseColorToken(token);
+  const key = rgbKey(rgba);
+  if (options.pinned.has(key)) return token;
   const hsl = rgbToHsl(rgba);
-  if (hsl.s < SATURATION_MIN) return token;
+  if (hsl.s < SATURATION_MIN && !options.themedExtra.has(key)) return token;
 
   const mapped = hslToRgb(remapHsl(hsl, from, to));
   if (token.startsWith("#")) {
@@ -114,20 +126,41 @@ const transformToken = (token, from, to) => {
     : `rgb(${mapped.r}, ${mapped.g}, ${mapped.b})`;
 };
 
-export const rethemeHtml = (html, fromBrand, toBrand) => {
+export const rethemeHtml = (html, fromBrand, toBrand, overrides) => {
   const from = rgbToHsl(hexToRgba(fromBrand));
   const to = rgbToHsl(hexToRgba(toBrand));
+  const options = buildOptions(overrides);
   return html.replace(STYLE_CONTEXT_RE, (chunk) =>
-    chunk.replace(COLOR_TOKEN_RE, (token) => transformToken(token, from, to)),
+    chunk.replace(COLOR_TOKEN_RE, (token) =>
+      transformToken(token, from, to, options),
+    ),
   );
 };
 
-export const rethemeCssColor = (color, fromBrand, toBrand) => {
+export const extractThemedColors = (html, overrides) => {
+  const options = buildOptions(overrides);
+  const found = new Map();
+  for (const chunk of html.match(STYLE_CONTEXT_RE) ?? []) {
+    for (const token of chunk.match(COLOR_TOKEN_RE) ?? []) {
+      const rgba = parseColorToken(token);
+      const key = rgbKey(rgba);
+      if (found.has(key) || options.pinned.has(key)) continue;
+      const hsl = rgbToHsl(rgba);
+      if (hsl.s < SATURATION_MIN && !options.themedExtra.has(key)) continue;
+      found.set(key, { hex: rgbToHex(rgba), hsl });
+    }
+  }
+  return [...found.values()]
+    .sort((a, b) => a.hsl.h - b.hsl.h || a.hsl.l - b.hsl.l)
+    .map((color) => color.hex);
+};
+
+export const rethemeCssColor = (color, fromBrand, toBrand, overrides) => {
   const match = color.match(COLOR_TOKEN_RE);
   if (!match || match[0] !== color.trim()) return color;
   const from = rgbToHsl(hexToRgba(fromBrand));
   const to = rgbToHsl(hexToRgba(toBrand));
-  return transformToken(color.trim(), from, to);
+  return transformToken(color.trim(), from, to, buildOptions(overrides));
 };
 
 const contrastWithWhite = (hex) => {
@@ -140,15 +173,24 @@ const contrastWithWhite = (hex) => {
   return 1.05 / (luminance + 0.05);
 };
 
-export const initCustomizer = ({ brand, background, loadHtml, onApply }) => {
+export const initCustomizer = ({
+  brand,
+  background,
+  pinned,
+  themedExtra,
+  loadHtml,
+  onApply,
+}) => {
   const menu = document.getElementById("customize-menu");
   const button = document.getElementById("customize-button");
   const panel = document.getElementById("customize-panel");
   const colorInput = document.getElementById("brand-color-input");
   const hexInput = document.getElementById("brand-hex-input");
   const hint = document.getElementById("contrast-hint");
+  const paletteDots = document.getElementById("palette-dots");
   const swatches = Array.from(panel.querySelectorAll("[data-swatch]"));
   const originalSwatch = panel.querySelector('[data-swatch="original"]');
+  const MAX_PALETTE_DOTS = 8;
 
   button.hidden = false;
   originalSwatch.style.setProperty("--swatch", brand);
@@ -158,9 +200,32 @@ export const initCustomizer = ({ brand, background, loadHtml, onApply }) => {
   let originalHtml = null;
   const ensureHtml = async () => (originalHtml ??= await loadHtml());
 
+  const renderPaletteDots = (html) => {
+    const colors = extractThemedColors(html, { pinned, themedExtra });
+    const overflow = colors.length - MAX_PALETTE_DOTS;
+    paletteDots.replaceChildren(
+      ...colors.slice(0, MAX_PALETTE_DOTS).map((hex) => {
+        const dot = document.createElement("span");
+        dot.className = "palette-dot";
+        dot.style.setProperty("--dot", hex);
+        dot.title = hex;
+        return dot;
+      }),
+    );
+    if (overflow > 0) {
+      const more = document.createElement("span");
+      more.className = "palette-dot-more";
+      more.textContent = `+${overflow}`;
+      paletteDots.append(more);
+    }
+  };
+
   const setPanelOpen = (isOpen) => {
     panel.hidden = !isOpen;
     button.setAttribute("aria-expanded", String(isOpen));
+    if (isOpen && !paletteDots.childElementCount) {
+      ensureHtml().then(renderPaletteDots);
+    }
   };
 
   const setActiveSwatch = (hex) => {
@@ -177,12 +242,15 @@ export const initCustomizer = ({ brand, background, loadHtml, onApply }) => {
   const applyBrand = async (hex) => {
     const html = await ensureHtml();
     const isOriginal = hex.toLowerCase() === brand.toLowerCase();
+    const overrides = { pinned, themedExtra };
+    const themedHtml = isOriginal ? html : rethemeHtml(html, brand, hex, overrides);
     onApply({
-      html: isOriginal ? html : rethemeHtml(html, brand, hex),
+      html: themedHtml,
       background: isOriginal
         ? background
-        : rethemeCssColor(background, brand, hex),
+        : rethemeCssColor(background, brand, hex, overrides),
     });
+    renderPaletteDots(themedHtml);
     colorInput.value = hex;
     hexInput.value = hex;
     setActiveSwatch(hex);

--- a/customizer.js
+++ b/customizer.js
@@ -187,10 +187,9 @@ export const initCustomizer = ({
   const colorInput = document.getElementById("brand-color-input");
   const hexInput = document.getElementById("brand-hex-input");
   const hint = document.getElementById("contrast-hint");
-  const paletteDots = document.getElementById("palette-dots");
+  const paletteStrip = document.getElementById("palette-strip");
   const swatches = Array.from(panel.querySelectorAll("[data-swatch]"));
   const originalSwatch = panel.querySelector('[data-swatch="original"]');
-  const MAX_PALETTE_DOTS = 8;
 
   button.hidden = false;
   originalSwatch.style.setProperty("--swatch", brand);
@@ -200,31 +199,24 @@ export const initCustomizer = ({
   let originalHtml = null;
   const ensureHtml = async () => (originalHtml ??= await loadHtml());
 
-  const renderPaletteDots = (html) => {
+  const renderPaletteStrip = (html) => {
     const colors = extractThemedColors(html, { pinned, themedExtra });
-    const overflow = colors.length - MAX_PALETTE_DOTS;
-    paletteDots.replaceChildren(
-      ...colors.slice(0, MAX_PALETTE_DOTS).map((hex) => {
-        const dot = document.createElement("span");
-        dot.className = "palette-dot";
-        dot.style.setProperty("--dot", hex);
-        dot.title = hex;
-        return dot;
+    paletteStrip.replaceChildren(
+      ...colors.map((hex) => {
+        const segment = document.createElement("span");
+        segment.className = "palette-strip-segment";
+        segment.style.setProperty("--segment", hex);
+        segment.title = hex;
+        return segment;
       }),
     );
-    if (overflow > 0) {
-      const more = document.createElement("span");
-      more.className = "palette-dot-more";
-      more.textContent = `+${overflow}`;
-      paletteDots.append(more);
-    }
   };
 
   const setPanelOpen = (isOpen) => {
     panel.hidden = !isOpen;
     button.setAttribute("aria-expanded", String(isOpen));
-    if (isOpen && !paletteDots.childElementCount) {
-      ensureHtml().then(renderPaletteDots);
+    if (isOpen && !paletteStrip.childElementCount) {
+      ensureHtml().then(renderPaletteStrip);
     }
   };
 
@@ -250,7 +242,7 @@ export const initCustomizer = ({
         ? background
         : rethemeCssColor(background, brand, hex, overrides),
     });
-    renderPaletteDots(themedHtml);
+    renderPaletteStrip(themedHtml);
     colorInput.value = hex;
     hexInput.value = hex;
     setActiveSwatch(hex);

--- a/customizer.js
+++ b/customizer.js
@@ -96,6 +96,20 @@ const parseColorToken = (token) => {
 
 const rgbKey = ({ r, g, b }) => `${r},${g},${b}`;
 
+const hueDistance = (a, b) => {
+  const d = Math.abs(a - b) % 360;
+  return d > 180 ? 360 - d : d;
+};
+
+// Each pair anchors one hue family: themed colors follow whichever anchor is
+// nearest by hue, so a template's brand and accent can be repicked separately.
+const buildAnchors = (pairs) =>
+  pairs.map(({ from, to }) => ({
+    identity: from.toLowerCase() === to.toLowerCase(),
+    from: rgbToHsl(hexToRgba(from)),
+    to: rgbToHsl(hexToRgba(to)),
+  }));
+
 // pinned: semantic colors (success badges, warnings) that must never follow
 // the brand. themedExtra: colors below the saturation threshold that still
 // belong to the brand family (e.g. muted browns in a warm monochrome theme).
@@ -104,14 +118,21 @@ const buildOptions = ({ pinned = [], themedExtra = [] } = {}) => ({
   themedExtra: new Set(themedExtra.map((c) => rgbKey(hexToRgba(c)))),
 });
 
-const transformToken = (token, from, to, options) => {
+const transformToken = (token, anchors, options) => {
   const rgba = parseColorToken(token);
   const key = rgbKey(rgba);
   if (options.pinned.has(key)) return token;
   const hsl = rgbToHsl(rgba);
   if (hsl.s < SATURATION_MIN && !options.themedExtra.has(key)) return token;
 
-  const mapped = hslToRgb(remapHsl(hsl, from, to));
+  const anchor = anchors.reduce((best, candidate) =>
+    hueDistance(hsl.h, candidate.from.h) < hueDistance(hsl.h, best.from.h)
+      ? candidate
+      : best,
+  );
+  if (anchor.identity) return token;
+
+  const mapped = hslToRgb(remapHsl(hsl, anchor.from, anchor.to));
   if (token.startsWith("#")) {
     const hex = rgbToHex(mapped);
     return rgba.a < 1
@@ -126,23 +147,20 @@ const transformToken = (token, from, to, options) => {
     : `rgb(${mapped.r}, ${mapped.g}, ${mapped.b})`;
 };
 
-export const rethemeHtml = (html, fromBrand, toBrand, overrides) => {
-  const from = rgbToHsl(hexToRgba(fromBrand));
-  const to = rgbToHsl(hexToRgba(toBrand));
+export const rethemeHtml = (html, pairs, overrides) => {
+  const anchors = buildAnchors(pairs);
   const options = buildOptions(overrides);
   return html.replace(STYLE_CONTEXT_RE, (chunk) =>
     chunk.replace(COLOR_TOKEN_RE, (token) =>
-      transformToken(token, from, to, options),
+      transformToken(token, anchors, options),
     ),
   );
 };
 
-export const rethemeCssColor = (color, fromBrand, toBrand, overrides) => {
+export const rethemeCssColor = (color, pairs, overrides) => {
   const match = color.match(COLOR_TOKEN_RE);
   if (!match || match[0] !== color.trim()) return color;
-  const from = rgbToHsl(hexToRgba(fromBrand));
-  const to = rgbToHsl(hexToRgba(toBrand));
-  return transformToken(color.trim(), from, to, buildOptions(overrides));
+  return transformToken(color.trim(), buildAnchors(pairs), buildOptions(overrides));
 };
 
 const contrastWithWhite = (hex) => {
@@ -155,8 +173,65 @@ const contrastWithWhite = (hex) => {
   return 1.05 / (luminance + 0.05);
 };
 
+const initColorControl = (section, original, onPick) => {
+  const swatches = Array.from(section.querySelectorAll("[data-swatch]"));
+  const colorInput = section.querySelector('input[type="color"]');
+  const hexInput = section.querySelector('input[type="text"]');
+  section
+    .querySelector('[data-swatch="original"]')
+    .style.setProperty("--swatch", original);
+
+  const state = { value: original };
+
+  const setValue = (hex) => {
+    state.value = hex;
+    colorInput.value = hex;
+    hexInput.value = hex;
+    swatches.forEach((swatch) => {
+      const value =
+        swatch.dataset.swatch === "original" ? original : swatch.dataset.swatch;
+      swatch.classList.toggle(
+        "is-active",
+        value.toLowerCase() === hex.toLowerCase(),
+      );
+    });
+  };
+  setValue(original);
+
+  swatches.forEach((swatch) => {
+    swatch.addEventListener("click", () => {
+      setValue(
+        swatch.dataset.swatch === "original" ? original : swatch.dataset.swatch,
+      );
+      onPick();
+    });
+  });
+
+  let debounceTimer;
+  colorInput.addEventListener("input", () => {
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      setValue(colorInput.value);
+      onPick();
+    }, 150);
+  });
+
+  hexInput.addEventListener("change", () => {
+    const value = hexInput.value.trim().replace(/^([0-9a-f]{6})$/i, "#$1");
+    if (/^#[0-9a-f]{6}$/i.test(value)) {
+      setValue(value);
+      onPick();
+    } else {
+      hexInput.value = state.value;
+    }
+  });
+
+  return state;
+};
+
 export const initCustomizer = ({
   brand,
+  accent,
   background,
   pinned,
   themedExtra,
@@ -166,16 +241,11 @@ export const initCustomizer = ({
   const menu = document.getElementById("customize-menu");
   const button = document.getElementById("customize-button");
   const panel = document.getElementById("customize-panel");
-  const colorInput = document.getElementById("brand-color-input");
-  const hexInput = document.getElementById("brand-hex-input");
   const hint = document.getElementById("contrast-hint");
-  const swatches = Array.from(panel.querySelectorAll("[data-swatch]"));
-  const originalSwatch = panel.querySelector('[data-swatch="original"]');
+  const brandSection = panel.querySelector('[data-color-control="brand"]');
+  const accentSection = panel.querySelector('[data-color-control="accent"]');
 
   button.hidden = false;
-  originalSwatch.style.setProperty("--swatch", brand);
-  colorInput.value = brand;
-  hexInput.value = brand;
 
   let originalHtml = null;
   const ensureHtml = async () => (originalHtml ??= await loadHtml());
@@ -185,52 +255,31 @@ export const initCustomizer = ({
     button.setAttribute("aria-expanded", String(isOpen));
   };
 
-  const setActiveSwatch = (hex) => {
-    swatches.forEach((swatch) => {
-      const value =
-        swatch.dataset.swatch === "original" ? brand : swatch.dataset.swatch;
-      swatch.classList.toggle(
-        "is-active",
-        value.toLowerCase() === hex.toLowerCase(),
-      );
-    });
-  };
-
-  const applyBrand = async (hex) => {
+  const applyTheme = async () => {
     const html = await ensureHtml();
-    const isOriginal = hex.toLowerCase() === brand.toLowerCase();
+    const pairs = [{ from: brand, to: brandControl.value }];
+    if (accentControl) pairs.push({ from: accent, to: accentControl.value });
+    const isOriginal = pairs.every(
+      ({ from, to }) => from.toLowerCase() === to.toLowerCase(),
+    );
     const overrides = { pinned, themedExtra };
     onApply({
-      html: isOriginal ? html : rethemeHtml(html, brand, hex, overrides),
+      html: isOriginal ? html : rethemeHtml(html, pairs, overrides),
       background: isOriginal
         ? background
-        : rethemeCssColor(background, brand, hex, overrides),
+        : rethemeCssColor(background, pairs, overrides),
     });
-    colorInput.value = hex;
-    hexInput.value = hex;
-    setActiveSwatch(hex);
-    hint.hidden = isOriginal || contrastWithWhite(hex) >= 3;
+    const brandChanged =
+      brandControl.value.toLowerCase() !== brand.toLowerCase();
+    hint.hidden = !brandChanged || contrastWithWhite(brandControl.value) >= 3;
   };
 
-  swatches.forEach((swatch) => {
-    swatch.addEventListener("click", () => {
-      const value =
-        swatch.dataset.swatch === "original" ? brand : swatch.dataset.swatch;
-      applyBrand(value);
-    });
-  });
-
-  let debounceTimer;
-  colorInput.addEventListener("input", () => {
-    clearTimeout(debounceTimer);
-    debounceTimer = setTimeout(() => applyBrand(colorInput.value), 150);
-  });
-
-  hexInput.addEventListener("change", () => {
-    const value = hexInput.value.trim().replace(/^([0-9a-f]{6})$/i, "#$1");
-    if (/^#[0-9a-f]{6}$/i.test(value)) applyBrand(value);
-    else hexInput.value = colorInput.value;
-  });
+  const brandControl = initColorControl(brandSection, brand, applyTheme);
+  let accentControl = null;
+  if (accent) {
+    accentSection.hidden = false;
+    accentControl = initColorControl(accentSection, accent, applyTheme);
+  }
 
   button.addEventListener("click", (event) => {
     event.stopPropagation();

--- a/customizer.js
+++ b/customizer.js
@@ -1,0 +1,226 @@
+// Brand-color customizer: re-themes a template by transforming its whole
+// saturated palette relative to one brand color, so tints/shades stay in sync.
+
+const SATURATION_MIN = 0.3;
+
+const clamp01 = (value) => Math.min(1, Math.max(0, value));
+
+const hexToRgba = (hex) => {
+  let digits = hex.slice(1);
+  if (digits.length <= 4) {
+    digits = [...digits].map((char) => char + char).join("");
+  }
+  const int = parseInt(digits.slice(0, 6), 16);
+  return {
+    r: (int >> 16) & 255,
+    g: (int >> 8) & 255,
+    b: int & 255,
+    a: digits.length === 8 ? parseInt(digits.slice(6, 8), 16) / 255 : 1,
+  };
+};
+
+const rgbToHsl = ({ r, g, b }) => {
+  const red = r / 255;
+  const green = g / 255;
+  const blue = b / 255;
+  const max = Math.max(red, green, blue);
+  const min = Math.min(red, green, blue);
+  const delta = max - min;
+  const l = (max + min) / 2;
+
+  if (delta === 0) return { h: 0, s: 0, l };
+
+  const s = delta / (1 - Math.abs(2 * l - 1));
+  let h;
+  if (max === red) h = ((green - blue) / delta) % 6;
+  else if (max === green) h = (blue - red) / delta + 2;
+  else h = (red - green) / delta + 4;
+  h = (h * 60 + 360) % 360;
+
+  return { h, s: clamp01(s), l };
+};
+
+const hslToRgb = ({ h, s, l }) => {
+  const chroma = (1 - Math.abs(2 * l - 1)) * s;
+  const x = chroma * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = l - chroma / 2;
+  const sextant = Math.floor(h / 60) % 6;
+  const [red, green, blue] = [
+    [chroma, x, 0],
+    [x, chroma, 0],
+    [0, chroma, x],
+    [0, x, chroma],
+    [x, 0, chroma],
+    [chroma, 0, x],
+  ][sextant];
+
+  return {
+    r: Math.round((red + m) * 255),
+    g: Math.round((green + m) * 255),
+    b: Math.round((blue + m) * 255),
+  };
+};
+
+const rgbToHex = ({ r, g, b }) =>
+  "#" + [r, g, b].map((v) => v.toString(16).padStart(2, "0")).join("");
+
+// Shift a color by the same relative move the brand color makes: hue by
+// delta, saturation by ratio, lightness proportionally into the headroom
+// left above/below the new brand lightness (keeps tints from clipping).
+const remapHsl = (hsl, from, to) => {
+  const h = (to.h + (hsl.h - from.h) + 360) % 360;
+  const s = from.s > 0 ? clamp01(hsl.s * (to.s / from.s)) : hsl.s;
+  const offset = hsl.l - from.l;
+  const l =
+    offset >= 0
+      ? clamp01(to.l + (from.l >= 1 ? 0 : offset * ((1 - to.l) / (1 - from.l))))
+      : clamp01(to.l + (from.l <= 0 ? 0 : offset * (to.l / from.l)));
+  return { h, s, l };
+};
+
+const HEX_TOKEN = "#(?:[0-9a-f]{8}|[0-9a-f]{6}|[0-9a-f]{4}|[0-9a-f]{3})(?![0-9a-f])";
+const RGB_TOKEN =
+  "rgba?\\(\\s*\\d{1,3}\\s*,\\s*\\d{1,3}\\s*,\\s*\\d{1,3}\\s*(?:,\\s*(?:\\d*\\.)?\\d+\\s*)?\\)";
+const COLOR_TOKEN_RE = new RegExp(`${HEX_TOKEN}|${RGB_TOKEN}`, "gi");
+
+// Only rewrite colors inside style contexts so hex-like text content
+// (e.g. "Order number: #6200600") is never touched.
+const STYLE_CONTEXT_RE =
+  /<style\b[\s\S]*?<\/style>|\b(?:style|bgcolor|color|fill|stroke)\s*=\s*"[^"]*"/gi;
+
+const parseColorToken = (token) => {
+  if (token.startsWith("#")) return hexToRgba(token);
+  const numbers = token.match(/[\d.]+/g).map(Number);
+  return { r: numbers[0], g: numbers[1], b: numbers[2], a: numbers[3] ?? 1 };
+};
+
+const transformToken = (token, from, to) => {
+  const rgba = parseColorToken(token);
+  const hsl = rgbToHsl(rgba);
+  if (hsl.s < SATURATION_MIN) return token;
+
+  const mapped = hslToRgb(remapHsl(hsl, from, to));
+  if (token.startsWith("#")) {
+    const hex = rgbToHex(mapped);
+    return rgba.a < 1
+      ? hex +
+          Math.round(rgba.a * 255)
+            .toString(16)
+            .padStart(2, "0")
+      : hex;
+  }
+  return token.toLowerCase().startsWith("rgba")
+    ? `rgba(${mapped.r}, ${mapped.g}, ${mapped.b}, ${rgba.a})`
+    : `rgb(${mapped.r}, ${mapped.g}, ${mapped.b})`;
+};
+
+export const rethemeHtml = (html, fromBrand, toBrand) => {
+  const from = rgbToHsl(hexToRgba(fromBrand));
+  const to = rgbToHsl(hexToRgba(toBrand));
+  return html.replace(STYLE_CONTEXT_RE, (chunk) =>
+    chunk.replace(COLOR_TOKEN_RE, (token) => transformToken(token, from, to)),
+  );
+};
+
+export const rethemeCssColor = (color, fromBrand, toBrand) => {
+  const match = color.match(COLOR_TOKEN_RE);
+  if (!match || match[0] !== color.trim()) return color;
+  const from = rgbToHsl(hexToRgba(fromBrand));
+  const to = rgbToHsl(hexToRgba(toBrand));
+  return transformToken(color.trim(), from, to);
+};
+
+const contrastWithWhite = (hex) => {
+  const channel = (v) => {
+    const c = v / 255;
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  };
+  const { r, g, b } = hexToRgba(hex);
+  const luminance = 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+  return 1.05 / (luminance + 0.05);
+};
+
+export const initCustomizer = ({ brand, background, loadHtml, onApply }) => {
+  const menu = document.getElementById("customize-menu");
+  const button = document.getElementById("customize-button");
+  const panel = document.getElementById("customize-panel");
+  const colorInput = document.getElementById("brand-color-input");
+  const hexInput = document.getElementById("brand-hex-input");
+  const hint = document.getElementById("contrast-hint");
+  const swatches = Array.from(panel.querySelectorAll("[data-swatch]"));
+  const originalSwatch = panel.querySelector('[data-swatch="original"]');
+
+  button.hidden = false;
+  originalSwatch.style.setProperty("--swatch", brand);
+  colorInput.value = brand;
+  hexInput.value = brand;
+
+  let originalHtml = null;
+  const ensureHtml = async () => (originalHtml ??= await loadHtml());
+
+  const setPanelOpen = (isOpen) => {
+    panel.hidden = !isOpen;
+    button.setAttribute("aria-expanded", String(isOpen));
+  };
+
+  const setActiveSwatch = (hex) => {
+    swatches.forEach((swatch) => {
+      const value =
+        swatch.dataset.swatch === "original" ? brand : swatch.dataset.swatch;
+      swatch.classList.toggle(
+        "is-active",
+        value.toLowerCase() === hex.toLowerCase(),
+      );
+    });
+  };
+
+  const applyBrand = async (hex) => {
+    const html = await ensureHtml();
+    const isOriginal = hex.toLowerCase() === brand.toLowerCase();
+    onApply({
+      html: isOriginal ? html : rethemeHtml(html, brand, hex),
+      background: isOriginal
+        ? background
+        : rethemeCssColor(background, brand, hex),
+    });
+    colorInput.value = hex;
+    hexInput.value = hex;
+    setActiveSwatch(hex);
+    hint.hidden = isOriginal || contrastWithWhite(hex) >= 3;
+  };
+
+  swatches.forEach((swatch) => {
+    swatch.addEventListener("click", () => {
+      const value =
+        swatch.dataset.swatch === "original" ? brand : swatch.dataset.swatch;
+      applyBrand(value);
+    });
+  });
+
+  let debounceTimer;
+  colorInput.addEventListener("input", () => {
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => applyBrand(colorInput.value), 150);
+  });
+
+  hexInput.addEventListener("change", () => {
+    const value = hexInput.value.trim().replace(/^([0-9a-f]{6})$/i, "#$1");
+    if (/^#[0-9a-f]{6}$/i.test(value)) applyBrand(value);
+    else hexInput.value = colorInput.value;
+  });
+
+  button.addEventListener("click", (event) => {
+    event.stopPropagation();
+    setPanelOpen(panel.hidden);
+  });
+
+  panel.addEventListener("click", (event) => event.stopPropagation());
+
+  document.addEventListener("click", (event) => {
+    if (!menu.contains(event.target)) setPanelOpen(false);
+  });
+
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "Escape") setPanelOpen(false);
+  });
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "tailwindcss-animated": "^1.1.2"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "autoprefixer": "^10.4.20",
         "cheerio": "^1.0.0-rc.12",
         "gh-pages": "^6.2.0",
@@ -931,6 +932,22 @@
         "node": ">=14"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.24.4",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.24.4.tgz",
@@ -1337,7 +1354,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001669",
         "electron-to-chromium": "^1.5.41",
@@ -2623,6 +2639,53 @@
         "node": ">=8"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.4.47",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
@@ -2641,7 +2704,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.0",
@@ -3272,7 +3334,6 @@
       "version": "3.4.14",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.14.tgz",
       "integrity": "sha512-IcSvOcTRcUtQQ7ILQL5quRDg7Xs93PdJEk1ZLbhhvJc7uj/OAhYOnruEiwnGgBvUtaUAJ8/mhSw1o8L2jCiENA==",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -3426,7 +3487,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.10.tgz",
       "integrity": "sha512-1hvaPshuPUtxeQ0hsVH3Mud0ZanOLwVTneA1EgbAM5LhaZEqyPWGRQ7BtaMvUrTDeEaC8pxtj6a6jku3x4z6SQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   ],
   "scripts": {
     "dev": "vite",
+    "test": "node --test",
     "build": "node scripts/optimize-previews.cjs --check && vite build && node scripts/copy-template-text.cjs && node scripts/generate-seo.cjs",
     "copy:template-text": "node scripts/copy-template-text.cjs",
     "optimize:previews": "node scripts/optimize-previews.cjs",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "dev": "vite",
     "test": "node --test",
+    "test:e2e": "playwright test",
     "build": "node scripts/optimize-previews.cjs --check && vite build && node scripts/copy-template-text.cjs && node scripts/generate-seo.cjs",
     "copy:template-text": "node scripts/copy-template-text.cjs",
     "optimize:previews": "node scripts/optimize-previews.cjs",
@@ -21,6 +22,7 @@
     "deploy": "npm run build && gh-pages -d dist"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "autoprefixer": "^10.4.20",
     "cheerio": "^1.0.0-rc.12",
     "gh-pages": "^6.2.0",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,27 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./playwright",
+  outputDir: "./verification/playwright-results",
+  fullyParallel: true,
+  reporter: [
+    ["line"],
+    [
+      "html",
+      {
+        outputFolder: "verification/playwright-report",
+        open: "never",
+      },
+    ],
+  ],
+  use: {
+    baseURL: "http://127.0.0.1:4173/email-templates/",
+    screenshot: "only-on-failure",
+    trace: "retain-on-failure",
+  },
+  webServer: {
+    command: "npm run dev -- --host 127.0.0.1 --port 4173",
+    url: "http://127.0.0.1:4173/email-templates/",
+    reuseExistingServer: false,
+  },
+});

--- a/playwright/customizer.spec.js
+++ b/playwright/customizer.spec.js
@@ -1,0 +1,105 @@
+import { expect, test } from "@playwright/test";
+
+const customizableTemplates = [
+  ["purchase-confirmation", 1],
+  ["ecommerce-order", 1],
+  ["shipping-confirmation", 1],
+  ["promotional-offer", 1],
+  ["shopping-deals", 1],
+  ["gift-decor", 2],
+  ["product-announcements", 1],
+  ["ai-newsletter", 1],
+  ["music-event-promotion", 2],
+  ["abandoned-cart", 1],
+  ["password-reset", 1],
+  ["account-verification", 1],
+  ["welcome-onboarding", 1],
+  ["product-review", 1],
+  ["reengagement", 1],
+  ["account-billing-update", 1],
+  ["product-promotion", 1],
+];
+
+for (const [templateId, expectedControlCount] of customizableTemplates) {
+  test(`${templateId} keeps swatch selection exclusive`, async ({ page }) => {
+    await page.goto(`preview.html?template=${templateId}`);
+
+    const customizeButton = page.locator("#customize-button");
+    await expect(customizeButton).toBeVisible();
+    await customizeButton.click();
+    await expect(page.locator("#customize-panel")).toBeVisible();
+    const controls = page.locator(
+      '#customize-panel [data-color-control]:not([hidden])',
+    );
+    await expect(controls).toHaveCount(expectedControlCount);
+
+    for (let index = 0; index < expectedControlCount; index += 1) {
+      const control = controls.nth(index);
+      const swatches = control.locator("[data-swatch]");
+      const originalSwatch = control.locator('[data-swatch="original"]');
+      const initialHex = await control.locator('input[type="text"]').inputValue();
+
+      await expect(originalSwatch).toHaveAttribute("aria-pressed", "true");
+      await expect(
+        control.locator('[data-swatch][aria-pressed="true"]'),
+      ).toHaveCount(1);
+
+      const swatchCount = await swatches.count();
+      for (let swatchIndex = 0; swatchIndex < swatchCount; swatchIndex += 1) {
+        const swatch = swatches.nth(swatchIndex);
+        await swatch.click();
+        await expect(swatch).toHaveAttribute("aria-pressed", "true");
+        await expect(
+          control.locator('[data-swatch][aria-pressed="true"]'),
+        ).toHaveCount(1);
+      }
+
+      const hexInput = control.locator('input[type="text"]');
+      await hexInput.fill("123456");
+      await hexInput.dispatchEvent("change");
+      await expect(hexInput).toHaveValue("#123456");
+      await expect(
+        control.locator('[data-swatch][aria-pressed="true"]'),
+      ).toHaveCount(0);
+
+      const colorInput = control.locator('input[type="color"]');
+      await colorInput.evaluate((input) => {
+        input.value = "#654321";
+        input.dispatchEvent(new Event("input", { bubbles: true }));
+      });
+      await expect(hexInput).toHaveValue("#654321");
+      await expect(
+        control.locator('[data-swatch][aria-pressed="true"]'),
+      ).toHaveCount(0);
+
+      await originalSwatch.click();
+      await expect(originalSwatch).toHaveAttribute("aria-pressed", "true");
+      await expect(hexInput).toHaveValue(initialHex);
+      await expect(
+        control.locator('[data-swatch][aria-pressed="true"]'),
+      ).toHaveCount(1);
+    }
+
+    const originalHtml = await page.evaluate(async (path) => {
+      const response = await fetch(path);
+      return response.text();
+    }, `templates/${templateId}.html`);
+    const brandControl = controls.first();
+    await brandControl.locator("[data-swatch]").last().click();
+
+    const frame = page.locator("#template-frame");
+    await expect.poll(() => frame.getAttribute("srcdoc")).not.toBe(originalHtml);
+    await expect(page.locator("#download-link")).toHaveAttribute(
+      "href",
+      /^blob:/,
+    );
+
+    await brandControl.locator('[data-swatch="original"]').click();
+    await expect.poll(() => frame.getAttribute("srcdoc")).toBe(originalHtml);
+  });
+}
+
+test("product-confirmation correctly has no customizer", async ({ page }) => {
+  await page.goto("preview.html?template=product-confirmation");
+  await expect(page.locator("#customize-button")).toBeHidden();
+});

--- a/preview.css
+++ b/preview.css
@@ -205,9 +205,14 @@ body {
   text-transform: uppercase;
 }
 
-.customize-label + .customize-label,
-.swatch-row + .customize-label {
+.color-control + .color-control {
+  border-top: 1px solid var(--border);
   margin-top: 14px;
+  padding-top: 14px;
+}
+
+.swatch-row + .customize-custom {
+  margin-top: 12px;
 }
 
 .customize-note {

--- a/preview.css
+++ b/preview.css
@@ -217,31 +217,23 @@ body {
   margin: -4px 0 10px;
 }
 
-.palette-dots {
-  align-items: center;
+.palette-strip {
+  border-radius: 4px;
   display: flex;
-  flex-wrap: wrap;
-  gap: 4px;
+  height: 8px;
   margin-bottom: 12px;
+  outline: 1px solid rgba(23, 32, 51, 0.12);
+  outline-offset: -1px;
+  overflow: hidden;
 }
 
-.palette-dots:empty {
+.palette-strip:empty {
   display: none;
 }
 
-.palette-dot {
-  background: var(--dot);
-  border: 1px solid rgba(23, 32, 51, 0.18);
-  border-radius: 50%;
-  height: 14px;
-  width: 14px;
-}
-
-.palette-dot-more {
-  color: var(--muted);
-  font-size: 11px;
-  font-weight: 600;
-  margin-left: 2px;
+.palette-strip-segment {
+  background: var(--segment);
+  flex: 1;
 }
 
 .swatch-row {

--- a/preview.css
+++ b/preview.css
@@ -125,6 +125,10 @@ body {
   padding: 0 14px;
 }
 
+.action-button[hidden] {
+  display: none;
+}
+
 .copy-menu {
   position: relative;
 }

--- a/preview.css
+++ b/preview.css
@@ -175,6 +175,108 @@ body {
   outline: none;
 }
 
+.customize-menu {
+  position: relative;
+}
+
+.customize-panel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 12px 30px rgba(23, 32, 51, 0.14);
+  padding: 14px;
+  position: absolute;
+  right: 0;
+  top: calc(100% + 8px);
+  width: 232px;
+  z-index: 20;
+}
+
+.customize-panel[hidden] {
+  display: none;
+}
+
+.customize-label {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  margin: 0 0 8px;
+  text-transform: uppercase;
+}
+
+.customize-label + .customize-label,
+.swatch-row + .customize-label {
+  margin-top: 14px;
+}
+
+.swatch-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.swatch {
+  background: var(--swatch, #ffffff);
+  border: 1px solid rgba(23, 32, 51, 0.18);
+  border-radius: 50%;
+  cursor: pointer;
+  height: 26px;
+  padding: 0;
+  width: 26px;
+}
+
+.swatch:hover {
+  transform: scale(1.08);
+}
+
+.swatch.is-active {
+  box-shadow:
+    0 0 0 2px var(--surface),
+    0 0 0 4px var(--accent);
+}
+
+.customize-custom {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+}
+
+.customize-custom input[type="color"] {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  cursor: pointer;
+  height: 34px;
+  padding: 2px;
+  width: 42px;
+}
+
+.customize-custom input[type="text"] {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text);
+  flex: 1;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  height: 34px;
+  min-width: 0;
+  padding: 0 10px;
+}
+
+.customize-custom input[type="text"]:focus-visible {
+  border-color: var(--accent);
+  outline: none;
+}
+
+.customize-hint {
+  color: #b45309;
+  font-size: 12px;
+  line-height: 1.4;
+  margin: 10px 0 0;
+}
+
 .action-button:disabled {
   cursor: default;
   opacity: 0.72;

--- a/preview.css
+++ b/preview.css
@@ -217,25 +217,6 @@ body {
   margin: -4px 0 10px;
 }
 
-.palette-strip {
-  border-radius: 4px;
-  display: flex;
-  height: 8px;
-  margin-bottom: 12px;
-  outline: 1px solid rgba(23, 32, 51, 0.12);
-  outline-offset: -1px;
-  overflow: hidden;
-}
-
-.palette-strip:empty {
-  display: none;
-}
-
-.palette-strip-segment {
-  background: var(--segment);
-  flex: 1;
-}
-
 .swatch-row {
   display: flex;
   flex-wrap: wrap;

--- a/preview.css
+++ b/preview.css
@@ -210,6 +210,40 @@ body {
   margin-top: 14px;
 }
 
+.customize-note {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+  margin: -4px 0 10px;
+}
+
+.palette-dots {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-bottom: 12px;
+}
+
+.palette-dots:empty {
+  display: none;
+}
+
+.palette-dot {
+  background: var(--dot);
+  border: 1px solid rgba(23, 32, 51, 0.18);
+  border-radius: 50%;
+  height: 14px;
+  width: 14px;
+}
+
+.palette-dot-more {
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 600;
+  margin-left: 2px;
+}
+
 .swatch-row {
   display: flex;
   flex-wrap: wrap;

--- a/preview.html
+++ b/preview.html
@@ -83,6 +83,7 @@
                 <button
                   class="swatch"
                   type="button"
+                  aria-pressed="false"
                   data-swatch="original"
                   title="Original"
                   aria-label="Original brand color"
@@ -90,6 +91,7 @@
                 <button
                   class="swatch"
                   type="button"
+                  aria-pressed="false"
                   data-swatch="#4f46e5"
                   style="--swatch: #4f46e5"
                   title="Indigo"
@@ -98,6 +100,7 @@
                 <button
                   class="swatch"
                   type="button"
+                  aria-pressed="false"
                   data-swatch="#0ea5e9"
                   style="--swatch: #0ea5e9"
                   title="Sky"
@@ -106,6 +109,7 @@
                 <button
                   class="swatch"
                   type="button"
+                  aria-pressed="false"
                   data-swatch="#059669"
                   style="--swatch: #059669"
                   title="Emerald"
@@ -114,6 +118,7 @@
                 <button
                   class="swatch"
                   type="button"
+                  aria-pressed="false"
                   data-swatch="#d97706"
                   style="--swatch: #d97706"
                   title="Amber"
@@ -122,6 +127,7 @@
                 <button
                   class="swatch"
                   type="button"
+                  aria-pressed="false"
                   data-swatch="#e11d48"
                   style="--swatch: #e11d48"
                   title="Rose"
@@ -130,6 +136,7 @@
                 <button
                   class="swatch"
                   type="button"
+                  aria-pressed="false"
                   data-swatch="#7c3aed"
                   style="--swatch: #7c3aed"
                   title="Violet"
@@ -155,6 +162,7 @@
                 <button
                   class="swatch"
                   type="button"
+                  aria-pressed="false"
                   data-swatch="original"
                   title="Original"
                   aria-label="Original accent color"
@@ -162,6 +170,7 @@
                 <button
                   class="swatch"
                   type="button"
+                  aria-pressed="false"
                   data-swatch="#4f46e5"
                   style="--swatch: #4f46e5"
                   title="Indigo"
@@ -170,6 +179,7 @@
                 <button
                   class="swatch"
                   type="button"
+                  aria-pressed="false"
                   data-swatch="#0ea5e9"
                   style="--swatch: #0ea5e9"
                   title="Sky"
@@ -178,6 +188,7 @@
                 <button
                   class="swatch"
                   type="button"
+                  aria-pressed="false"
                   data-swatch="#059669"
                   style="--swatch: #059669"
                   title="Emerald"
@@ -186,6 +197,7 @@
                 <button
                   class="swatch"
                   type="button"
+                  aria-pressed="false"
                   data-swatch="#d97706"
                   style="--swatch: #d97706"
                   title="Amber"
@@ -194,6 +206,7 @@
                 <button
                   class="swatch"
                   type="button"
+                  aria-pressed="false"
                   data-swatch="#e11d48"
                   style="--swatch: #e11d48"
                   title="Rose"
@@ -202,6 +215,7 @@
                 <button
                   class="swatch"
                   type="button"
+                  aria-pressed="false"
                   data-swatch="#7c3aed"
                   style="--swatch: #7c3aed"
                   title="Violet"

--- a/preview.html
+++ b/preview.html
@@ -78,11 +78,6 @@
               Recolors this template's brand palette — neutral elements keep
               their design.
             </p>
-            <div
-              class="palette-strip"
-              id="palette-strip"
-              aria-label="Colors in this template that will change"
-            ></div>
             <div class="swatch-row">
               <button
                 class="swatch"

--- a/preview.html
+++ b/preview.html
@@ -79,8 +79,8 @@
               their design.
             </p>
             <div
-              class="palette-dots"
-              id="palette-dots"
+              class="palette-strip"
+              id="palette-strip"
               aria-label="Colors in this template that will change"
             ></div>
             <div class="swatch-row">

--- a/preview.html
+++ b/preview.html
@@ -70,85 +70,156 @@
             class="customize-panel"
             id="customize-panel"
             role="group"
-            aria-label="Brand color"
+            aria-label="Template colors"
             hidden
           >
-            <p class="customize-label">Brand color</p>
-            <p class="customize-note">
-              Recolors this template's brand palette — neutral elements keep
-              their design.
-            </p>
-            <div class="swatch-row">
-              <button
-                class="swatch"
-                type="button"
-                data-swatch="original"
-                title="Original"
-                aria-label="Original brand color"
-              ></button>
-              <button
-                class="swatch"
-                type="button"
-                data-swatch="#4f46e5"
-                style="--swatch: #4f46e5"
-                title="Indigo"
-                aria-label="Indigo"
-              ></button>
-              <button
-                class="swatch"
-                type="button"
-                data-swatch="#0ea5e9"
-                style="--swatch: #0ea5e9"
-                title="Sky"
-                aria-label="Sky"
-              ></button>
-              <button
-                class="swatch"
-                type="button"
-                data-swatch="#059669"
-                style="--swatch: #059669"
-                title="Emerald"
-                aria-label="Emerald"
-              ></button>
-              <button
-                class="swatch"
-                type="button"
-                data-swatch="#d97706"
-                style="--swatch: #d97706"
-                title="Amber"
-                aria-label="Amber"
-              ></button>
-              <button
-                class="swatch"
-                type="button"
-                data-swatch="#e11d48"
-                style="--swatch: #e11d48"
-                title="Rose"
-                aria-label="Rose"
-              ></button>
-              <button
-                class="swatch"
-                type="button"
-                data-swatch="#7c3aed"
-                style="--swatch: #7c3aed"
-                title="Violet"
-                aria-label="Violet"
-              ></button>
+            <div class="color-control" data-color-control="brand">
+              <p class="customize-label">Brand color</p>
+              <p class="customize-note">
+                Recolors this template's brand palette — neutral elements keep
+                their design.
+              </p>
+              <div class="swatch-row">
+                <button
+                  class="swatch"
+                  type="button"
+                  data-swatch="original"
+                  title="Original"
+                  aria-label="Original brand color"
+                ></button>
+                <button
+                  class="swatch"
+                  type="button"
+                  data-swatch="#4f46e5"
+                  style="--swatch: #4f46e5"
+                  title="Indigo"
+                  aria-label="Indigo"
+                ></button>
+                <button
+                  class="swatch"
+                  type="button"
+                  data-swatch="#0ea5e9"
+                  style="--swatch: #0ea5e9"
+                  title="Sky"
+                  aria-label="Sky"
+                ></button>
+                <button
+                  class="swatch"
+                  type="button"
+                  data-swatch="#059669"
+                  style="--swatch: #059669"
+                  title="Emerald"
+                  aria-label="Emerald"
+                ></button>
+                <button
+                  class="swatch"
+                  type="button"
+                  data-swatch="#d97706"
+                  style="--swatch: #d97706"
+                  title="Amber"
+                  aria-label="Amber"
+                ></button>
+                <button
+                  class="swatch"
+                  type="button"
+                  data-swatch="#e11d48"
+                  style="--swatch: #e11d48"
+                  title="Rose"
+                  aria-label="Rose"
+                ></button>
+                <button
+                  class="swatch"
+                  type="button"
+                  data-swatch="#7c3aed"
+                  style="--swatch: #7c3aed"
+                  title="Violet"
+                  aria-label="Violet"
+                ></button>
+              </div>
+              <div class="customize-custom">
+                <input
+                  type="color"
+                  aria-label="Pick a custom brand color"
+                />
+                <input
+                  type="text"
+                  spellcheck="false"
+                  maxlength="7"
+                  aria-label="Brand color hex value"
+                />
+              </div>
             </div>
-            <p class="customize-label">Custom</p>
-            <div class="customize-custom">
-              <input
-                type="color"
-                id="brand-color-input"
-                aria-label="Pick a custom brand color"
-              />
-              <input
-                type="text"
-                id="brand-hex-input"
-                spellcheck="false"
-                maxlength="7"
-                aria-label="Brand color hex value"
-              />
+            <div class="color-control" data-color-control="accent" hidden>
+              <p class="customize-label">Accent color</p>
+              <div class="swatch-row">
+                <button
+                  class="swatch"
+                  type="button"
+                  data-swatch="original"
+                  title="Original"
+                  aria-label="Original accent color"
+                ></button>
+                <button
+                  class="swatch"
+                  type="button"
+                  data-swatch="#4f46e5"
+                  style="--swatch: #4f46e5"
+                  title="Indigo"
+                  aria-label="Indigo"
+                ></button>
+                <button
+                  class="swatch"
+                  type="button"
+                  data-swatch="#0ea5e9"
+                  style="--swatch: #0ea5e9"
+                  title="Sky"
+                  aria-label="Sky"
+                ></button>
+                <button
+                  class="swatch"
+                  type="button"
+                  data-swatch="#059669"
+                  style="--swatch: #059669"
+                  title="Emerald"
+                  aria-label="Emerald"
+                ></button>
+                <button
+                  class="swatch"
+                  type="button"
+                  data-swatch="#d97706"
+                  style="--swatch: #d97706"
+                  title="Amber"
+                  aria-label="Amber"
+                ></button>
+                <button
+                  class="swatch"
+                  type="button"
+                  data-swatch="#e11d48"
+                  style="--swatch: #e11d48"
+                  title="Rose"
+                  aria-label="Rose"
+                ></button>
+                <button
+                  class="swatch"
+                  type="button"
+                  data-swatch="#7c3aed"
+                  style="--swatch: #7c3aed"
+                  title="Violet"
+                  aria-label="Violet"
+                ></button>
+              </div>
+              <div class="customize-custom">
+                <input
+                  type="color"
+                  aria-label="Pick a custom accent color"
+                />
+                <input
+                  type="text"
+                  spellcheck="false"
+                  maxlength="7"
+                  aria-label="Accent color hex value"
+                />
+              </div>
             </div>
             <p class="customize-hint" id="contrast-hint" hidden>
               Light brand colors can make white button text hard to read.

--- a/preview.html
+++ b/preview.html
@@ -41,6 +41,116 @@
       </div>
 
       <div class="toolbar-right">
+        <div class="customize-menu" id="customize-menu">
+          <button
+            class="action-button secondary"
+            type="button"
+            id="customize-button"
+            aria-haspopup="true"
+            aria-expanded="false"
+            hidden
+          >
+            <svg
+              class="icon"
+              viewBox="0 0 20 20"
+              fill="none"
+              aria-hidden="true"
+            >
+              <path
+                d="M10 3.5C10 3.5 4.5 9 4.5 12.5C4.5 15.54 6.96 17.5 10 17.5C13.04 17.5 15.5 15.54 15.5 12.5C15.5 9 10 3.5 10 3.5Z"
+                stroke="currentColor"
+                stroke-width="1.7"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            <span>Customize</span>
+          </button>
+          <div
+            class="customize-panel"
+            id="customize-panel"
+            role="group"
+            aria-label="Brand color"
+            hidden
+          >
+            <p class="customize-label">Brand color</p>
+            <div class="swatch-row">
+              <button
+                class="swatch"
+                type="button"
+                data-swatch="original"
+                title="Original"
+                aria-label="Original brand color"
+              ></button>
+              <button
+                class="swatch"
+                type="button"
+                data-swatch="#4f46e5"
+                style="--swatch: #4f46e5"
+                title="Indigo"
+                aria-label="Indigo"
+              ></button>
+              <button
+                class="swatch"
+                type="button"
+                data-swatch="#0ea5e9"
+                style="--swatch: #0ea5e9"
+                title="Sky"
+                aria-label="Sky"
+              ></button>
+              <button
+                class="swatch"
+                type="button"
+                data-swatch="#059669"
+                style="--swatch: #059669"
+                title="Emerald"
+                aria-label="Emerald"
+              ></button>
+              <button
+                class="swatch"
+                type="button"
+                data-swatch="#d97706"
+                style="--swatch: #d97706"
+                title="Amber"
+                aria-label="Amber"
+              ></button>
+              <button
+                class="swatch"
+                type="button"
+                data-swatch="#e11d48"
+                style="--swatch: #e11d48"
+                title="Rose"
+                aria-label="Rose"
+              ></button>
+              <button
+                class="swatch"
+                type="button"
+                data-swatch="#7c3aed"
+                style="--swatch: #7c3aed"
+                title="Violet"
+                aria-label="Violet"
+              ></button>
+            </div>
+            <p class="customize-label">Custom</p>
+            <div class="customize-custom">
+              <input
+                type="color"
+                id="brand-color-input"
+                aria-label="Pick a custom brand color"
+              />
+              <input
+                type="text"
+                id="brand-hex-input"
+                spellcheck="false"
+                maxlength="7"
+                aria-label="Brand color hex value"
+              />
+            </div>
+            <p class="customize-hint" id="contrast-hint" hidden>
+              Light brand colors can make white button text hard to read.
+            </p>
+          </div>
+        </div>
         <div class="copy-menu" id="copy-menu">
           <button
             class="action-button secondary"

--- a/preview.html
+++ b/preview.html
@@ -74,6 +74,15 @@
             hidden
           >
             <p class="customize-label">Brand color</p>
+            <p class="customize-note">
+              Recolors this template's brand palette — neutral elements keep
+              their design.
+            </p>
+            <div
+              class="palette-dots"
+              id="palette-dots"
+              aria-label="Colors in this template that will change"
+            ></div>
             <div class="swatch-row">
               <button
                 class="swatch"

--- a/preview.js
+++ b/preview.js
@@ -1,3 +1,5 @@
+import { initCustomizer } from "./customizer.js";
+
 const templates = {
   "purchase-confirmation": {
     title: "Purchase Confirmation Emailer",
@@ -18,11 +20,13 @@ const templates = {
     title: "Shipping Confirmation Emailer",
     file: "./templates/shipping-confirmation.html",
     background: "#eff6ff",
+    brand: "#2563eb",
   },
   "promotional-offer": {
     title: "Promotional Offer Emailer",
     file: "./templates/promotional-offer.html",
     background: "#ff9b12",
+    brand: "#ff9b12",
   },
   "shopping-deals": {
     title: "Shopping Deals Emailer",
@@ -58,6 +62,7 @@ const templates = {
     title: "Password Reset Emailer",
     file: "./templates/password-reset.html",
     background: "#f4f4f4",
+    brand: "#667eea",
   },
   "account-verification": {
     title: "Account Verification Emailer",
@@ -226,11 +231,11 @@ const getFileContent = async (file) => {
   return response.text();
 };
 
-const copyFileToClipboard = async (button, file, successText) => {
+const copyFileToClipboard = async (button, getContent, successText) => {
   const original = button.innerHTML;
   button.disabled = true;
   try {
-    const content = await getFileContent(file);
+    const content = await getContent();
     await navigator.clipboard.writeText(content);
     button.textContent = successText;
     setTimeout(() => {
@@ -254,12 +259,20 @@ copyMenuButton.addEventListener("click", (event) => {
 
 copyHtmlMenuItem.addEventListener("click", () => {
   setCopyMenuOpen(false);
-  copyFileToClipboard(copyMenuButton, template.file, "HTML copied");
+  copyFileToClipboard(
+    copyMenuButton,
+    () => currentHtml ?? getFileContent(template.file),
+    "HTML copied",
+  );
 });
 
 copyTextMenuItem.addEventListener("click", () => {
   setCopyMenuOpen(false);
-  copyFileToClipboard(copyMenuButton, plainTextFile, "Text copied");
+  copyFileToClipboard(
+    copyMenuButton,
+    () => getFileContent(plainTextFile),
+    "Text copied",
+  );
 });
 
 document.addEventListener("click", (event) => {
@@ -269,3 +282,24 @@ document.addEventListener("click", (event) => {
 document.addEventListener("keydown", (event) => {
   if (event.key === "Escape") setCopyMenuOpen(false);
 });
+
+let currentHtml = null;
+let downloadBlobUrl = null;
+
+if (template.brand) {
+  initCustomizer({
+    brand: template.brand,
+    background: template.background,
+    loadHtml: () => getFileContent(template.file),
+    onApply: ({ html, background }) => {
+      currentHtml = html;
+      frame.srcdoc = html;
+      stage.style.setProperty("--template-bg", background);
+      if (downloadBlobUrl) URL.revokeObjectURL(downloadBlobUrl);
+      downloadBlobUrl = URL.createObjectURL(
+        new Blob([html], { type: "text/html" }),
+      );
+      downloadLink.href = downloadBlobUrl;
+    },
+  });
+}

--- a/preview.js
+++ b/preview.js
@@ -41,6 +41,7 @@ const templates = {
     file: "./templates/gift-decor.html",
     background: "rgb(36, 3, 54)",
     brand: "#ffd700",
+    accent: "#663399",
   },
   "product-announcements": {
     title: "Product Announcements Emailer",
@@ -60,6 +61,7 @@ const templates = {
     file: "./templates/music-event-promotion.html",
     background: "#f4f4f4",
     brand: "#ffd700",
+    accent: "#007bff",
   },
   "abandoned-cart": {
     title: "Abandoned Cart Emailer",
@@ -306,6 +308,7 @@ let downloadBlobUrl = null;
 if (template.brand) {
   initCustomizer({
     brand: template.brand,
+    accent: template.accent,
     background: template.background,
     pinned: template.pinned,
     themedExtra: template.themedExtra,

--- a/preview.js
+++ b/preview.js
@@ -5,6 +5,7 @@ const templates = {
     title: "Purchase Confirmation Emailer",
     file: "./templates/purchase-confirmation.html",
     background: "#f4f4f4",
+    brand: "#00bfa5",
   },
   "product-confirmation": {
     title: "Product Confirmation Emailer",
@@ -15,6 +16,7 @@ const templates = {
     title: "Ecommerce Order Emailer",
     file: "./templates/ecommerce-order.html",
     background: "#fff5f0",
+    brand: "#ff4d4d",
   },
   "shipping-confirmation": {
     title: "Shipping Confirmation Emailer",
@@ -32,31 +34,38 @@ const templates = {
     title: "Shopping Deals Emailer",
     file: "./templates/shopping-deals.html",
     background: "#f4f4f4",
+    brand: "#7cff64",
   },
   "gift-decor": {
     title: "Gift Decor Emailer",
     file: "./templates/gift-decor.html",
     background: "rgb(36, 3, 54)",
+    brand: "#ffd700",
   },
   "product-announcements": {
     title: "Product Announcements Emailer",
     file: "./templates/product-announcements.html",
     background: "#ffffff",
+    brand: "#4f46e5",
+    pinned: ["#dcfce7", "#f0fdf4", "#166534"],
   },
   "ai-newsletter": {
     title: "AI Newsletter Emailer",
     file: "./templates/ai-newsletter.html",
     background: "#06120d",
+    brand: "#007bff",
   },
   "music-event-promotion": {
     title: "Music Event Promotion Emailer",
     file: "./templates/music-event-promotion.html",
     background: "#f4f4f4",
+    brand: "#ffd700",
   },
   "abandoned-cart": {
     title: "Abandoned Cart Emailer",
     file: "./templates/abandoned-cart.html",
     background: "#ffffff",
+    brand: "#0ea5e9",
   },
   "password-reset": {
     title: "Password Reset Emailer",
@@ -68,31 +77,39 @@ const templates = {
     title: "Account Verification Emailer",
     file: "./templates/account-verification.html",
     background: "#fafaf9",
+    brand: "#d4a574",
+    themedExtra: ["#8b7355", "#a8998a", "#5c4b37", "#e8e3dd"],
   },
   "welcome-onboarding": {
     title: "Welcome Onboarding Emailer",
     file: "./templates/welcome-onboarding.html",
     background: "#f4f4f4",
+    brand: "#f59e0b",
   },
   "product-review": {
     title: "Product Review HTML Template",
     file: "./templates/product-review.html",
     background: "#f4f4f4",
+    brand: "#065f46",
   },
   reengagement: {
     title: "Re-engagement HTML Email",
     file: "./templates/reengagement.html",
     background: "#f8fafc",
+    brand: "#f97316",
   },
   "account-billing-update": {
     title: "Account & Billing Update Emailer",
     file: "./templates/account-billing-update.html",
     background: "#eef2f7",
+    brand: "#2563eb",
+    pinned: ["#f59e0b"],
   },
   "product-promotion": {
     title: "Product Promotion HTML Email Template",
     file: "./templates/product-promotion.html",
     background: "#141a08",
+    brand: "#c9d36a",
   },
 };
 
@@ -290,6 +307,8 @@ if (template.brand) {
   initCustomizer({
     brand: template.brand,
     background: template.background,
+    pinned: template.pinned,
+    themedExtra: template.themedExtra,
     loadHtml: () => getFileContent(template.file),
     onApply: ({ html, background }) => {
       currentHtml = html;

--- a/test/customizer.test.js
+++ b/test/customizer.test.js
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { rethemeHtml } from "../customizer.js";
+
+test("rethemes HTML, SVG, and Outlook VML color attributes", () => {
+  const html = `
+    <style>.cta { background: #667eea; }</style>
+    <td bgcolor="#667eea" style='background: #667eea'>
+      <svg fill="#667eea" stroke='#667eea'></svg>
+      <v:roundrect fillcolor="#667eea" strokecolor='#667eea'></v:roundrect>
+    </td>
+    <p>Reference #667eea</p>
+  `;
+
+  const themed = rethemeHtml(html, [
+    { from: "#667eea", to: "#e11d48" },
+  ]);
+
+  assert.match(themed, /background: #e11d48/);
+  assert.match(themed, /bgcolor="#e11d48"/);
+  assert.match(themed, /fill="#e11d48"/);
+  assert.match(themed, /stroke='#e11d48'/);
+  assert.match(themed, /fillcolor="#e11d48"/);
+  assert.match(themed, /strokecolor='#e11d48'/);
+  assert.match(themed, /<p>Reference #667eea<\/p>/);
+});

--- a/test/customizer.test.js
+++ b/test/customizer.test.js
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 import { rethemeHtml } from "../customizer.js";
@@ -24,4 +25,19 @@ test("rethemes HTML, SVG, and Outlook VML color attributes", () => {
   assert.match(themed, /fillcolor="#e11d48"/);
   assert.match(themed, /strokecolor='#e11d48'/);
   assert.match(themed, /<p>Reference #667eea<\/p>/);
+});
+
+test("every color swatch exposes an initial pressed state", async () => {
+  const previewHtml = await readFile(
+    new URL("../preview.html", import.meta.url),
+    "utf8",
+  );
+  const swatches = previewHtml.match(
+    /<button\s+class="swatch"[\s\S]*?<\/button>/g,
+  );
+
+  assert.ok(swatches?.length, "expected color swatch buttons");
+  swatches.forEach((swatch) => {
+    assert.match(swatch, /aria-pressed="false"/);
+  });
 });


### PR DESCRIPTION
- Adds live brand and accent color customization to 17 email templates.
- Updates previews, copied HTML, and downloaded HTML with the selected palette.
- Preserves neutral and semantic colors, including Outlook VML support.
- Improves swatch accessibility and adds focused regression tests.
