### PR TITLE
fix: absolute image URLs and Gmail-safe CSS in templates

### DIFF
--- a/templates/ecommerce-order.html
+++ b/templates/ecommerce-order.html
@@ -82,7 +82,7 @@
           >
             <tr>
               <td>
-                <img src="/acme.png" alt="acme" style="height: 24px" />
+                <img src="https://nirajrajgor.github.io/email-templates/acme.png" alt="acme" style="height: 24px" />
               </td>
               <td style="text-align: right">
                 <table
@@ -424,7 +424,7 @@
                   <tr>
                     <td width="80">
                       <img
-                        src="/apple-watch-ai-gen.webp"
+                        src="https://nirajrajgor.github.io/email-templates/apple-watch-ai-gen.webp"
                         alt="T-shirt"
                         style="
                           width: 80px;
@@ -676,7 +676,7 @@
             </div>
             <div style="float: right">
               <img
-                src="/size-chart.webp"
+                src="https://nirajrajgor.github.io/email-templates/size-chart.webp"
                 alt="Clothes rack"
                 style="width: 100%; max-width: 200px; border-radius: 8px"
               />

--- a/templates/ecommerce-order.html
+++ b/templates/ecommerce-order.html
@@ -66,7 +66,7 @@
         max-width: 600px;
         margin: 0 auto;
         background-color: white;
-        border: 2px solid rgb(248 250 252);
+        border: 2px solid #f8fafc;
         border-radius: 16px;
         font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
       "

--- a/templates/gift-decor.html
+++ b/templates/gift-decor.html
@@ -62,7 +62,7 @@
       <tr>
         <td bgcolor="#663399" style="padding: 10px; text-align: center">
           <img
-            src="/acme_white.png"
+            src="https://nirajrajgor.github.io/email-templates/acme_white.png"
             alt="Home Decor"
             style="color: #ffffff; max-width: 100px"
           />
@@ -116,7 +116,7 @@
       <tr>
         <td style="padding: 0">
           <img
-            src="/happy-mug-ai.webp"
+            src="https://nirajrajgor.github.io/email-templates/happy-mug-ai.webp"
             alt="Mighty Happy Mug"
             width="600"
             style="width: 100%; max-width: 600px; height: auto; display: block"
@@ -212,7 +212,7 @@
               <!-- Product Image -->
               <td width="50%" style="padding: 0">
                 <img
-                  src="/cupcake-ai-gen.webp"
+                  src="https://nirajrajgor.github.io/email-templates/cupcake-ai-gen.webp"
                   alt="Mighty Ghost Mug"
                   width="300"
                   style="
@@ -310,7 +310,7 @@
               <!-- Product Image -->
               <td width="50%" style="padding: 0">
                 <img
-                  src="/cupcake-ai-gen.webp"
+                  src="https://nirajrajgor.github.io/email-templates/cupcake-ai-gen.webp"
                   alt="Mighty Ghost Mug"
                   width="300"
                   style="
@@ -340,7 +340,7 @@
               <!-- Product Image -->
               <td width="50%" style="padding: 0">
                 <img
-                  src="/candle-decor-ai.webp"
+                  src="https://nirajrajgor.github.io/email-templates/candle-decor-ai.webp"
                   alt="Candles"
                   width="300"
                   style="
@@ -395,27 +395,27 @@
         <td style="padding: 40px 0px; background-color: #000000">
           <div style="text-align: center">
             <img
-              src="/acme_white.png"
+              src="https://nirajrajgor.github.io/email-templates/acme_white.png"
               alt="acme"
               style="height: 30px; margin: 0 15px; vertical-align: middle"
             />
             <img
-              src="/acme_white.png"
+              src="https://nirajrajgor.github.io/email-templates/acme_white.png"
               alt="acme"
               style="height: 30px; margin: 0 15px; vertical-align: middle"
             />
             <img
-              src="/acme_white.png"
+              src="https://nirajrajgor.github.io/email-templates/acme_white.png"
               alt="acme"
               style="height: 30px; margin: 0 15px; vertical-align: middle"
             />
             <img
-              src="/acme_white.png"
+              src="https://nirajrajgor.github.io/email-templates/acme_white.png"
               alt="acme"
               style="height: 30px; margin: 0 15px; vertical-align: middle"
             />
             <img
-              src="/acme_white.png"
+              src="https://nirajrajgor.github.io/email-templates/acme_white.png"
               alt="acme"
               style="height: 30px; margin: 0 15px; vertical-align: middle"
             />
@@ -451,27 +451,27 @@
             <!-- Star Rating -->
             <div style="margin-bottom: 20px">
               <img
-                src="/pink-star.svg"
+                src="https://nirajrajgor.github.io/email-templates/pink-star.svg"
                 alt="★"
                 style="height: 20px; margin: 0 2px"
               />
               <img
-                src="/pink-star.svg"
+                src="https://nirajrajgor.github.io/email-templates/pink-star.svg"
                 alt="★"
                 style="height: 20px; margin: 0 2px"
               />
               <img
-                src="/pink-star.svg"
+                src="https://nirajrajgor.github.io/email-templates/pink-star.svg"
                 alt="★"
                 style="height: 20px; margin: 0 2px"
               />
               <img
-                src="/pink-star.svg"
+                src="https://nirajrajgor.github.io/email-templates/pink-star.svg"
                 alt="★"
                 style="height: 20px; margin: 0 2px"
               />
               <img
-                src="/pink-star.svg"
+                src="https://nirajrajgor.github.io/email-templates/pink-star.svg"
                 alt="★"
                 style="height: 20px; margin: 0 2px"
               />
@@ -506,27 +506,27 @@
               >Excellent</span
             >
             <img
-              src="/green-star.svg"
+              src="https://nirajrajgor.github.io/email-templates/green-star.svg"
               alt="★"
               style="height: 18px; vertical-align: middle; margin-left: 5px"
             />
             <img
-              src="/green-star.svg"
+              src="https://nirajrajgor.github.io/email-templates/green-star.svg"
               alt="★"
               style="height: 18px; vertical-align: middle"
             />
             <img
-              src="/green-star.svg"
+              src="https://nirajrajgor.github.io/email-templates/green-star.svg"
               alt="★"
               style="height: 18px; vertical-align: middle"
             />
             <img
-              src="/green-star.svg"
+              src="https://nirajrajgor.github.io/email-templates/green-star.svg"
               alt="★"
               style="height: 18px; vertical-align: middle"
             />
             <img
-              src="/green-star.svg"
+              src="https://nirajrajgor.github.io/email-templates/green-star.svg"
               alt="★"
               style="height: 18px; vertical-align: middle"
             />
@@ -559,7 +559,7 @@
         >
           <!-- Witch Hat Image -->
           <img
-            src="/magic-hat-ai.png"
+            src="https://nirajrajgor.github.io/email-templates/magic-hat-ai.png"
             alt="Magic Hat"
             style="width: 120px; margin-bottom: 20px"
           />
@@ -583,21 +583,21 @@
             <tr>
               <td style="padding: 0 10px">
                 <img
-                  src="/candle-decor-ai.webp"
+                  src="https://nirajrajgor.github.io/email-templates/candle-decor-ai.webp"
                   alt="Gift Box"
                   style="width: 100%; max-width: 180px; height: auto"
                 />
               </td>
               <td style="padding: 0 10px">
                 <img
-                  src="/cupcake-ai-gen.webp"
+                  src="https://nirajrajgor.github.io/email-templates/cupcake-ai-gen.webp"
                   alt="Romantic Gift"
                   style="width: 100%; max-width: 180px; height: auto"
                 />
               </td>
               <td style="padding: 0 10px">
                 <img
-                  src="/candle-decor-ai.webp"
+                  src="https://nirajrajgor.github.io/email-templates/candle-decor-ai.webp"
                   alt="Candle Gift"
                   style="width: 100%; max-width: 180px; height: auto"
                 />
@@ -616,7 +616,7 @@
             text-align: center;
           "
         >
-          <img src="/acme_white.png" alt="Acme" style="width: 150px" />
+          <img src="https://nirajrajgor.github.io/email-templates/acme_white.png" alt="Acme" style="width: 150px" />
         </td>
       </tr>
 

--- a/templates/product-announcements.html
+++ b/templates/product-announcements.html
@@ -146,7 +146,7 @@
                         "
                       >
                         <img
-                          src="/download.svg"
+                          src="https://nirajrajgor.github.io/email-templates/download.svg"
                           alt="Feature icon"
                           width="24"
                           height="24"
@@ -219,7 +219,7 @@
                         "
                       >
                         <img
-                          src="/download.svg"
+                          src="https://nirajrajgor.github.io/email-templates/download.svg"
                           alt="Feature icon"
                           width="24"
                           height="24"
@@ -367,7 +367,7 @@
                         "
                       >
                         <img
-                          src="/green-star.svg"
+                          src="https://nirajrajgor.github.io/email-templates/green-star.svg"
                           alt="Feature icon"
                           width="24"
                           height="24"
@@ -451,7 +451,7 @@
                         "
                       >
                         <img
-                          src="/green-star.svg"
+                          src="https://nirajrajgor.github.io/email-templates/green-star.svg"
                           alt="Feature icon"
                           width="24"
                           height="24"
@@ -544,7 +544,7 @@
                         "
                       >
                         <img
-                          src="/download.svg"
+                          src="https://nirajrajgor.github.io/email-templates/download.svg"
                           alt="Feature icon"
                           width="24"
                           height="24"
@@ -620,7 +620,7 @@
                         "
                       >
                         <img
-                          src="/download.svg"
+                          src="https://nirajrajgor.github.io/email-templates/download.svg"
                           alt="Feature icon"
                           width="24"
                           height="24"

--- a/templates/product-confirmation.html
+++ b/templates/product-confirmation.html
@@ -65,7 +65,7 @@
             <tr>
               <td style="padding-bottom: 30px">
                 <img
-                  src="/acme.png"
+                  src="https://nirajrajgor.github.io/email-templates/acme.png"
                   alt="Company Logo"
                   style="width: 80px; height: 30px"
                 />
@@ -133,7 +133,7 @@
                   <tr>
                     <td width="80">
                       <img
-                        src="/apple-watch-ai-gen.webp"
+                        src="https://nirajrajgor.github.io/email-templates/apple-watch-ai-gen.webp"
                         alt="Apple Watch Ultra 2"
                         style="width: 80px; height: 80px; border-radius: 8px"
                       />

--- a/templates/product-review.html
+++ b/templates/product-review.html
@@ -116,7 +116,7 @@
             <tr>
               <td align="center" style="padding: 28px 20px 0 20px">
                 <img
-                  src="/acme.png"
+                  src="https://nirajrajgor.github.io/email-templates/acme.png"
                   alt="Acme"
                   width="72"
                   height="24"
@@ -192,7 +192,7 @@
                             style="padding-right: 12px"
                           >
                             <img
-                              src="/apple-watch-ai-gen.webp"
+                              src="https://nirajrajgor.github.io/email-templates/apple-watch-ai-gen.webp"
                               alt="Apple Watch Ultra 2"
                               width="64"
                               height="64"
@@ -250,7 +250,7 @@
                             style="padding-right: 12px"
                           >
                             <img
-                              src="/shoe-graphic.png"
+                              src="https://nirajrajgor.github.io/email-templates/shoe-graphic.png"
                               alt="Running Shoes"
                               width="64"
                               height="64"
@@ -307,7 +307,7 @@
                             style="padding-right: 12px"
                           >
                             <img
-                              src="/cupcake-ai-gen.webp"
+                              src="https://nirajrajgor.github.io/email-templates/cupcake-ai-gen.webp"
                               alt="Cupcake Gift Box"
                               width="64"
                               height="64"

--- a/templates/promotional-offer.html
+++ b/templates/promotional-offer.html
@@ -66,7 +66,7 @@
             <tr>
               <td align="center" style="padding: 20px">
                 <img
-                  src="/black-friday-text.png"
+                  src="https://nirajrajgor.github.io/email-templates/black-friday-text.png"
                   alt="Promotional Offer Emailer Image"
                   style="width: 300px; height: 400px"
                 />
@@ -152,7 +152,7 @@
                         <tr>
                           <td width="150" valign="top">
                             <img
-                              src="/processed_apple-watch-ai-gen.webp"
+                              src="https://nirajrajgor.github.io/email-templates/processed_apple-watch-ai-gen.webp"
                               alt="Jabra Elite 75t"
                               width="140"
                               height="140"
@@ -289,7 +289,7 @@
                           </td>
                           <td width="150" valign="top">
                             <img
-                              src="/processed_apple-watch-ai-gen.webp"
+                              src="https://nirajrajgor.github.io/email-templates/processed_apple-watch-ai-gen.webp"
                               alt="Apple AirPods"
                               width="140"
                               height="140"
@@ -337,7 +337,7 @@
                                   style="height: 140px; vertical-align: middle"
                                 >
                                   <img
-                                    src="/processed_apple-watch-ai-gen.webp"
+                                    src="https://nirajrajgor.github.io/email-templates/processed_apple-watch-ai-gen.webp"
                                     alt="Sony WH-100"
                                     width="140"
                                     height="140"
@@ -428,7 +428,7 @@
                                   style="height: 140px; vertical-align: middle"
                                 >
                                   <img
-                                    src="/processed_apple-watch-ai-gen.webp"
+                                    src="https://nirajrajgor.github.io/email-templates/processed_apple-watch-ai-gen.webp"
                                     alt="Bose QC45"
                                     width="140"
                                     height="140"
@@ -759,7 +759,7 @@
                           <!-- Right Content (Phone Image) -->
                           <td width="30%" style="vertical-align: bottom">
                             <img
-                              src="/mockup.png"
+                              src="https://nirajrajgor.github.io/email-templates/mockup.png"
                               alt="Appleee Mobile App"
                               width="150"
                               height="240"

--- a/templates/purchase-confirmation.html
+++ b/templates/purchase-confirmation.html
@@ -57,7 +57,7 @@
         >
           <!-- Logo placeholder -->
           <img
-            src="/acme_white.png"
+            src="https://nirajrajgor.github.io/email-templates/acme_white.png"
             alt="Logo"
             style="width: 120px; height: 30px; margin-bottom: 20px"
           />

--- a/templates/purchase-confirmation.html
+++ b/templates/purchase-confirmation.html
@@ -108,7 +108,7 @@
         </td>
       </tr>
 
-      <tr style="background-color: rgb(248 250 252)">
+      <tr style="background-color: #f8fafc">
         <td style="padding: 30px">
           <table
             role="presentation"

--- a/templates/shipping-confirmation.html
+++ b/templates/shipping-confirmation.html
@@ -117,7 +117,7 @@
           >
             <tr>
               <td>
-                <img src="/acme.png" alt="acme" style="height: 24px" />
+                <img src="https://nirajrajgor.github.io/email-templates/acme.png" alt="acme" style="height: 24px" />
               </td>
               <td style="text-align: right">
                 <table
@@ -547,7 +547,7 @@
                   <tr>
                     <td width="80">
                       <img
-                        src="/apple-watch-ai-gen.webp"
+                        src="https://nirajrajgor.github.io/email-templates/apple-watch-ai-gen.webp"
                         alt="Apple Watch"
                         style="
                           width: 80px;

--- a/templates/shopping-deals.html
+++ b/templates/shopping-deals.html
@@ -46,7 +46,7 @@
             <tr>
               <td align="center" style="padding: 0 20px 40px">
                 <img
-                  src="/acme_white.png"
+                  src="https://nirajrajgor.github.io/email-templates/acme_white.png"
                   alt="Acme"
                   style="display: block; width: 120px; max-width: 100%"
                 />
@@ -101,7 +101,7 @@
                     <!-- Right Content (Image) -->
                     <td width="60%" style="vertical-align: top">
                       <img
-                        src="/shoe-graphic.png"
+                        src="https://nirajrajgor.github.io/email-templates/shoe-graphic.png"
                         alt="Nike Sports Shoe"
                         style="
                           display: block;
@@ -180,7 +180,7 @@
                         </p>
 
                         <img
-                          src="/shoe-graphic.png"
+                          src="https://nirajrajgor.github.io/email-templates/shoe-graphic.png"
                           alt="Nike K-5000"
                           style="
                             display: block;
@@ -229,7 +229,7 @@
                           25% OFF
                         </p>
                         <img
-                          src="/shoe-graphic.png"
+                          src="https://nirajrajgor.github.io/email-templates/shoe-graphic.png"
                           alt="Puma"
                           style="
                             display: block;
@@ -281,7 +281,7 @@
                           20% OFF
                         </p>
                         <img
-                          src="/shoe-graphic.png"
+                          src="https://nirajrajgor.github.io/email-templates/shoe-graphic.png"
                           alt="Adidas"
                           style="
                             display: block;
@@ -330,7 +330,7 @@
                           30% OFF
                         </p>
                         <img
-                          src="/shoe-graphic.png"
+                          src="https://nirajrajgor.github.io/email-templates/shoe-graphic.png"
                           alt="Nikeeee"
                           style="
                             display: block;
@@ -418,7 +418,7 @@
                   "
                 >
                   <img
-                    src="/acme.png"
+                    src="https://nirajrajgor.github.io/email-templates/acme.png"
                     alt="acme logo"
                     style="display: block; width: 100%"
                   />
@@ -433,7 +433,7 @@
                   "
                 >
                   <img
-                    src="/acme.png"
+                    src="https://nirajrajgor.github.io/email-templates/acme.png"
                     alt="acme logo"
                     style="display: block; width: 100%"
                   />
@@ -448,7 +448,7 @@
                   "
                 >
                   <img
-                    src="/acme.png"
+                    src="https://nirajrajgor.github.io/email-templates/acme.png"
                     alt="acme logo"
                     style="display: block; width: 100%"
                   />
@@ -475,7 +475,7 @@
                   "
                 >
                   <img
-                    src="/acme.png"
+                    src="https://nirajrajgor.github.io/email-templates/acme.png"
                     alt="acme logo"
                     style="display: block; width: 100%"
                   />
@@ -490,7 +490,7 @@
                   "
                 >
                   <img
-                    src="/acme.png"
+                    src="https://nirajrajgor.github.io/email-templates/acme.png"
                     alt="acme logo"
                     style="display: block; width: 100%"
                   />
@@ -568,7 +568,7 @@
                         RUNNING
                       </h3>
                       <img
-                        src="/shoe-ai-gen.png"
+                        src="https://nirajrajgor.github.io/email-templates/shoe-ai-gen.png"
                         alt="Running Shoe"
                         style="
                           display: block;
@@ -601,7 +601,7 @@
                         LIFESTYLE
                       </h3>
                       <img
-                        src="/shoe-ai-gen.png"
+                        src="https://nirajrajgor.github.io/email-templates/shoe-ai-gen.png"
                         alt="Lifestyle Shoe"
                         style="
                           display: block;
@@ -635,7 +635,7 @@
                         TRAINER
                       </h3>
                       <img
-                        src="/shoe-ai-gen.png"
+                        src="https://nirajrajgor.github.io/email-templates/shoe-ai-gen.png"
                         alt="Trainer Shoe"
                         style="
                           display: block;
@@ -727,7 +727,7 @@
                     >
                       <!-- Post Image -->
                       <img
-                        src="/shoe-ai-gen.png"
+                        src="https://nirajrajgor.github.io/email-templates/shoe-ai-gen.png"
                         alt="Upcoming Release Sneakers"
                         style="
                           display: block;
@@ -811,7 +811,7 @@
                     >
                       <!-- Post Image -->
                       <img
-                        src="/shoe-ai-gen.png"
+                        src="https://nirajrajgor.github.io/email-templates/shoe-ai-gen.png"
                         alt="Most Wanted Sneakers"
                         style="
                           display: block;
@@ -894,7 +894,7 @@
                 style="vertical-align: top; padding-right: 2px"
               >
                 <img
-                  src="/shoe-ai-gen.png"
+                  src="https://nirajrajgor.github.io/email-templates/shoe-ai-gen.png"
                   alt="Sports Shoe"
                   style="
                     display: block;
@@ -978,7 +978,7 @@
                 style="vertical-align: top; padding-left: 2px"
               >
                 <img
-                  src="/shoe-ai-gen.png"
+                  src="https://nirajrajgor.github.io/email-templates/shoe-ai-gen.png"
                   alt="Sports Shoe"
                   style="
                     display: block;
@@ -1001,7 +1001,7 @@
         >
           <!-- Logo -->
           <img
-            src="/acme_white.png"
+            src="https://nirajrajgor.github.io/email-templates/acme_white.png"
             alt="Acme"
             style="
               display: block;


### PR DESCRIPTION
- Convert all root-relative image `src` paths to absolute `https://nirajrajgor.github.io/email-templates/...` URLs across 9 templates.
- Replace space-separated `rgb(248 250 252)` with `#f8fafc` in ecommerce-order and purchase-confirmation — Gmail's CSS sanitizer drops the entire inline style attribute when any declaration fails its parser, which stripped the main container's max-width/background/border-radius and broke the layout on both Gmail desktop and iOS